### PR TITLE
Fix subscription ID case mutation bug

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1282,7 +1282,6 @@ html.theme-transition *::after {
 
 .manual-id-input {
   font-family: 'DM Mono', monospace;
-  text-transform: uppercase;
   letter-spacing: 0.05em;
 }
 


### PR DESCRIPTION
Remove `text-transform: uppercase` from `.manual-id-input` to ensure manual IDs are displayed exactly as entered.

---
<a href="https://cursor.com/background-agent?bcId=bc-cfcf3c49-7560-43a8-b688-d029f7c5b94d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cfcf3c49-7560-43a8-b688-d029f7c5b94d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

