### PR TITLE
Investigate mqtt connection failure in attendant workflow

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -24,15 +24,6 @@ import {
   AttendantStep,
 } from './components';
 
-// MQTT Configuration interface
-interface MqttConfig {
-  username: string;
-  password: string;
-  clientId: string;
-  hostname: string;
-  port: number;
-}
-
 // Constants
 const PAYMENT_CONFIRMATION_ENDPOINT = "https://crm-omnivoltaic.odoo.com/api/lipay/manual-confirm";
 
@@ -42,7 +33,7 @@ interface AttendantFlowProps {
 
 export default function AttendantFlow({ onBack }: AttendantFlowProps) {
   const router = useRouter();
-  const { bridge } = useBridge();
+  const { bridge, isMqttConnected } = useBridge();
   
   // Attendant info from login
   const [attendantInfo, setAttendantInfo] = useState<{ id: string; station: string }>({
@@ -60,97 +51,6 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
       });
     }
   }, []);
-
-  // Initialize MQTT connection
-  useEffect(() => {
-    if (!bridge) {
-      console.info('Bridge not available yet, waiting for initialization...');
-      return;
-    }
-
-    console.info('=== Initializing MQTT Connection for Attendant Flow ===');
-
-    // Register the MQTT connection callback handler
-    bridge.registerHandler(
-      'connectMqttCallBack',
-      (data: string, responseCallback: (response: any) => void) => {
-        try {
-          const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
-          console.info('=== MQTT Connection Callback ===');
-          console.info('Connection Callback Data:', JSON.stringify(parsedData, null, 2));
-
-          // Check if connection was successful
-          const isConnected =
-            parsedData?.connected === true ||
-            parsedData?.status === 'connected' ||
-            parsedData?.respCode === '200' ||
-            (parsedData && !parsedData.error);
-
-          if (isConnected) {
-            console.info('MQTT connection confirmed as connected');
-            setIsMqttConnected(true);
-          } else {
-            console.warn('MQTT connection callback indicates not connected:', parsedData);
-            setIsMqttConnected(false);
-          }
-          responseCallback('Received MQTT Connection Callback');
-        } catch (err) {
-          console.error('Error parsing MQTT connection callback:', err);
-          // If we can't parse it, assume connection might be OK but log the error
-          console.warn('Assuming MQTT connection is OK despite parse error');
-          setIsMqttConnected(true);
-          responseCallback('Received MQTT Connection Callback');
-        }
-      }
-    );
-
-    // Generate unique client ID to avoid conflicts when multiple devices connect
-    const generateClientId = () => {
-      const timestamp = Date.now();
-      const random = Math.random().toString(36).substring(2, 9);
-      return `attendant-flow-${attendantInfo.id}-${timestamp}-${random}`;
-    };
-
-    // MQTT configuration matching your credentials
-    const mqttConfig: MqttConfig = {
-      username: 'Admin',
-      password: '7xzUV@MT',
-      clientId: generateClientId(),
-      hostname: 'mqtt.omnivoltaic.com',
-      port: 1883,
-    };
-
-    console.info('=== Initiating MQTT Connection ===');
-    console.info('MQTT Config:', { ...mqttConfig, password: '***' });
-
-    // Connect to MQTT
-    bridge.callHandler('connectMqtt', mqttConfig, (resp: string) => {
-      try {
-        const p = typeof resp === 'string' ? JSON.parse(resp) : resp;
-        console.info('=== MQTT Connect Response ===');
-        console.info('Connect Response:', JSON.stringify(p, null, 2));
-
-        if (p.error) {
-          console.error('MQTT connection error:', p.error.message || p.error);
-          setIsMqttConnected(false);
-          toast.error('Failed to connect to MQTT server');
-        } else if (p.respCode === '200' || p.success === true) {
-          console.info('MQTT connection initiated successfully');
-          // Connection state will be confirmed by connectMqttCallBack
-        } else {
-          console.warn('MQTT connection response indicates potential issue:', p);
-        }
-      } catch (err) {
-        console.error('Error parsing MQTT response:', err);
-        // Don't set connection to false on parse error, wait for callback
-      }
-    });
-
-    // Cleanup function
-    return () => {
-      console.info('Cleaning up MQTT connection handlers');
-    };
-  }, [bridge, attendantInfo.id]);
   
   // Step management
   const [currentStep, setCurrentStep] = useState<AttendantStep>(1);
@@ -204,9 +104,6 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
   
   // Ref for correlation ID
   const correlationIdRef = useRef<string>('');
-  
-  // MQTT connection state
-  const [isMqttConnected, setIsMqttConnected] = useState(false);
 
   // Get electricity service from service states
   const electricityService = serviceStates.find(

--- a/src/app/context/bridgeContext.tsx
+++ b/src/app/context/bridgeContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, ReactNode, useRef } from 'react';
 
 // Define the WebViewJavascriptBridge type as per your app
 interface WebViewJavascriptBridge {
@@ -9,9 +9,19 @@ interface WebViewJavascriptBridge {
   callHandler: (handlerName: string, data: any, callback: (responseData: string) => void) => void;
 }
 
+// MQTT Configuration interface
+interface MqttConfig {
+  username: string;
+  password: string;
+  clientId: string;
+  hostname: string;
+  port: number;
+}
+
 interface BridgeContextProps {
   bridge: WebViewJavascriptBridge | null;
   setBridge: React.Dispatch<React.SetStateAction<WebViewJavascriptBridge | null>>;
+  isMqttConnected: boolean;
 }
 
 // Create a context for the Bridge
@@ -33,7 +43,10 @@ interface BridgeProviderProps {
 
 export const BridgeProvider: React.FC<BridgeProviderProps> = ({ children }) => {
   const [bridge, setBridge] = useState<WebViewJavascriptBridge | null>(null);
+  const [isMqttConnected, setIsMqttConnected] = useState<boolean>(false);
+  const mqttInitializedRef = useRef<boolean>(false);
 
+  // Initialize Bridge
   useEffect(() => {
     const initializeBridge = () => {
       const ready = () => {
@@ -60,5 +73,100 @@ export const BridgeProvider: React.FC<BridgeProviderProps> = ({ children }) => {
     };
   }, []);
 
-  return <BridgeContext.Provider value={{ bridge, setBridge }}>{children}</BridgeContext.Provider>;
+  // Initialize MQTT connection when bridge becomes available
+  useEffect(() => {
+    if (!bridge || mqttInitializedRef.current) {
+      return;
+    }
+
+    console.info('=== Initializing Global MQTT Connection ===');
+    mqttInitializedRef.current = true;
+
+    // Register the MQTT connection callback handler
+    bridge.registerHandler(
+      'connectMqttCallBack',
+      (data: string, responseCallback: (response: any) => void) => {
+        try {
+          const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+          console.info('=== Global MQTT Connection Callback ===');
+          console.info('Connection Callback Data:', JSON.stringify(parsedData, null, 2));
+
+          // Check if connection was successful
+          const isConnected =
+            parsedData?.connected === true ||
+            parsedData?.status === 'connected' ||
+            parsedData?.respCode === '200' ||
+            (parsedData && !parsedData.error);
+
+          if (isConnected) {
+            console.info('Global MQTT connection confirmed as connected');
+            setIsMqttConnected(true);
+          } else {
+            console.warn('Global MQTT connection callback indicates not connected:', parsedData);
+            setIsMqttConnected(false);
+          }
+          responseCallback('Received MQTT Connection Callback');
+        } catch (err) {
+          console.error('Error parsing MQTT connection callback:', err);
+          // If we can't parse it, assume connection might be OK but log the error
+          console.warn('Assuming MQTT connection is OK despite parse error');
+          setIsMqttConnected(true);
+          responseCallback('Received MQTT Connection Callback');
+        }
+      }
+    );
+
+    // Generate unique client ID to avoid conflicts when multiple devices connect
+    const generateClientId = () => {
+      const timestamp = Date.now();
+      const random = Math.random().toString(36).substring(2, 9);
+      return `oves-app-${timestamp}-${random}`;
+    };
+
+    // MQTT configuration with your credentials
+    const mqttConfig: MqttConfig = {
+      username: 'Admin',
+      password: '7xzUV@MT',
+      clientId: generateClientId(),
+      hostname: 'mqtt.omnivoltaic.com',
+      port: 1883,
+    };
+
+    console.info('=== Initiating Global MQTT Connection ===');
+    console.info('MQTT Config:', { ...mqttConfig, password: '***' });
+
+    // Connect to MQTT
+    bridge.callHandler('connectMqtt', mqttConfig, (resp: string) => {
+      try {
+        const p = typeof resp === 'string' ? JSON.parse(resp) : resp;
+        console.info('=== Global MQTT Connect Response ===');
+        console.info('Connect Response:', JSON.stringify(p, null, 2));
+
+        if (p.error) {
+          console.error('Global MQTT connection error:', p.error.message || p.error);
+          setIsMqttConnected(false);
+        } else if (p.respCode === '200' || p.success === true) {
+          console.info('Global MQTT connection initiated successfully');
+          // Connection state will be confirmed by connectMqttCallBack
+        } else {
+          console.warn('Global MQTT connection response indicates potential issue:', p);
+        }
+      } catch (err) {
+        console.error('Error parsing MQTT response:', err);
+        // Don't set connection to false on parse error, wait for callback
+      }
+    });
+
+    // Cleanup function
+    return () => {
+      console.info('Cleaning up global MQTT connection handlers');
+      mqttInitializedRef.current = false;
+    };
+  }, [bridge]);
+
+  return (
+    <BridgeContext.Provider value={{ bridge, setBridge, isMqttConnected }}>
+      {children}
+    </BridgeContext.Provider>
+  );
 };


### PR DESCRIPTION
Globally initialize MQTT connection in `BridgeProvider` and ensure dependent components check its status.

This prevents "MQTT not connected" errors by establishing the connection once at the app level, as the entire application relies on MQTT, not just specific workflows.

---
<a href="https://cursor.com/background-agent?bcId=bc-601ce106-5206-4741-a621-8f0a2d136f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-601ce106-5206-4741-a621-8f0a2d136f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

