### PR TITLE
Debug identify customer response handling

### DIFF
--- a/src/app/(mobile)/attendant/attendant/swap.tsx
+++ b/src/app/(mobile)/attendant/attendant/swap.tsx
@@ -459,7 +459,7 @@ const deriveCustomerTypeFromPayload = (payload?: any) => {
 
             // Check if this is the specific customer identification response topic
             // Use currentPlanId from closure (subscriptionCode || dynamicPlanId)
-            const expectedResponseTopic = `echo/abs/service/plan/${currentPlanId}/identify_customer`;
+            const expectedResponseTopic = `echo/abs/attendant/plan/${currentPlanId}/identify_customer`;
             if (topic && topic === expectedResponseTopic) {
               console.info(
                 "Response received from customer identification topic:",
@@ -516,10 +516,12 @@ const deriveCustomerTypeFromPayload = (payload?: any) => {
                 console.info("Response signals:", signals);
 
                 // Check if response contains success: true and required signal
+                // IDEMPOTENT_OPERATION_DETECTED indicates a cached successful result
                 const hasRequiredSignal =
                   success === true &&
                   Array.isArray(signals) &&
-                  signals.includes("CUSTOMER_IDENTIFIED_SUCCESS");
+                  (signals.includes("CUSTOMER_IDENTIFIED_SUCCESS") ||
+                    signals.includes("IDEMPOTENT_OPERATION_DETECTED"));
 
                 console.info(
                   "Response has required signal:",
@@ -1409,10 +1411,12 @@ const deriveCustomerTypeFromPayload = (payload?: any) => {
                 console.info("Response signals:", signals);
 
                 // Check if response contains required signals
+                // IDEMPOTENT_OPERATION_DETECTED indicates a cached successful result
                 const hasRequiredSignal =
                   Array.isArray(signals) &&
                   (signals.includes("CUSTOMER_IDENTIFICATION_REQUESTED") ||
-                    signals.includes("CUSTOMER_IDENTIFIED_SUCCESS"));
+                    signals.includes("CUSTOMER_IDENTIFIED_SUCCESS") ||
+                    signals.includes("IDEMPOTENT_OPERATION_DETECTED"));
 
                 console.info(
                   "Response has required signal:",


### PR DESCRIPTION
Fix MQTT response handling for customer identification by correcting the topic and accepting `IDEMPOTENT_OPERATION_DETECTED` as a success signal.

The previous MQTT topic for customer identification responses was `echo/abs/service/...` instead of `echo/abs/attendant/...`, causing responses to be missed. Additionally, the `IDEMPOTENT_OPERATION_DETECTED` signal, which indicates a cached successful operation, was not recognized as a valid success signal.

---
<a href="https://cursor.com/background-agent?bcId=bc-a70952ba-8eab-46fa-ad54-ba34a07a6e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a70952ba-8eab-46fa-ad54-ba34a07a6e60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

