### PR TITLE
Improve payment and service state display

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/CustomerStatePanel.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/CustomerStatePanel.tsx
@@ -8,41 +8,41 @@ interface CustomerStatePanelProps {
   visible: boolean;
 }
 
-// Service Cycle FSM state styling
-const getServiceStateConfig = (state?: string): { className: string; label: string } => {
+// Service Cycle FSM state styling - uses cyan/teal palette
+const getServiceStateConfig = (state?: string): { className: string; label: string; shortLabel: string } => {
   switch (state) {
     case 'BATTERY_ISSUED':
-      return { className: 'service-battery-issued', label: 'Battery Issued' };
+      return { className: 'service-battery-issued', label: 'Battery Issued', shortLabel: 'Issued' };
     case 'WAIT_BATTERY_ISSUE':
-      return { className: 'service-wait-battery', label: 'Awaiting Battery' };
+      return { className: 'service-wait-battery', label: 'Awaiting Battery', shortLabel: 'Awaiting' };
     case 'BATTERY_RETURNED':
-      return { className: 'service-battery-returned', label: 'Battery Returned' };
+      return { className: 'service-battery-returned', label: 'Battery Returned', shortLabel: 'Returned' };
     case 'BATTERY_LOST':
-      return { className: 'service-battery-lost', label: 'Battery Lost' };
+      return { className: 'service-battery-lost', label: 'Battery Lost', shortLabel: 'Lost' };
     case 'COMPLETE':
-      return { className: 'service-complete', label: 'Complete' };
+      return { className: 'service-complete', label: 'Complete', shortLabel: 'Done' };
     case 'INITIAL':
     default:
-      return { className: 'service-initial', label: 'Initial' };
+      return { className: 'service-initial', label: 'Initial', shortLabel: 'New' };
   }
 };
 
-// Payment Cycle FSM state styling
-const getPaymentStateConfig = (state?: string): { className: string; label: string } => {
+// Payment Cycle FSM state styling - uses green/orange/red palette
+const getPaymentStateConfig = (state?: string): { className: string; label: string; shortLabel: string } => {
   switch (state) {
     case 'CURRENT':
-      return { className: 'payment-current', label: 'Current' };
+      return { className: 'payment-current', label: 'Current', shortLabel: 'Paid' };
     case 'DEPOSIT_DUE':
-      return { className: 'payment-deposit-due', label: 'Deposit Due' };
+      return { className: 'payment-deposit-due', label: 'Deposit Due', shortLabel: 'Deposit' };
     case 'RENEWAL_DUE':
-      return { className: 'payment-renewal-due', label: 'Renewal Due' };
+      return { className: 'payment-renewal-due', label: 'Renewal Due', shortLabel: 'Renew' };
     case 'FINAL_DUE':
-      return { className: 'payment-final-due', label: 'Final Due' };
+      return { className: 'payment-final-due', label: 'Final Due', shortLabel: 'Final' };
     case 'COMPLETE':
-      return { className: 'payment-complete', label: 'Complete' };
+      return { className: 'payment-complete', label: 'Complete', shortLabel: 'Done' };
     case 'INITIAL':
     default:
-      return { className: 'payment-initial', label: 'Initial' };
+      return { className: 'payment-initial', label: 'Initial', shortLabel: 'New' };
   }
 };
 
@@ -78,13 +78,19 @@ export default function CustomerStatePanel({ customer, visible }: CustomerStateP
               <div className="state-plan-row">
                 <span className="state-plan-name">{customer.subscriptionType}</span>
                 {customer.serviceState && (
-                  <span className={`state-badge ${serviceConfig.className}`}>
-                    {serviceConfig.label}
+                  <span className={`state-badge-group service`}>
+                    <span className="state-badge-label">Service</span>
+                    <span className={`state-badge ${serviceConfig.className}`}>
+                      {serviceConfig.shortLabel}
+                    </span>
                   </span>
                 )}
                 {customer.paymentState && (
-                  <span className={`state-badge ${paymentConfig.className}`}>
-                    {paymentConfig.label}
+                  <span className={`state-badge-group payment`}>
+                    <span className="state-badge-label">Payment</span>
+                    <span className={`state-badge ${paymentConfig.className}`}>
+                      {paymentConfig.shortLabel}
+                    </span>
                   </span>
                 )}
               </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2464,15 +2464,45 @@ html.theme-transition *::after {
 .state-plan-row {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   font-size: 10px;
   color: var(--text-secondary);
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 .state-plan-name {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 90px;
+  flex-shrink: 1;
+}
+
+/* State badge groups - contains label + badge */
+.state-badge-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  flex-shrink: 0;
+  max-width: 100px;
+}
+
+.state-badge-label {
+  font-size: 8px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.2px;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
+.state-badge-group.service .state-badge-label {
+  color: var(--accent);
+}
+
+.state-badge-group.payment .state-badge-label {
+  color: var(--success);
 }
 
 /* Status badges */
@@ -2486,22 +2516,26 @@ html.theme-transition *::after {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.3px;
+  white-space: nowrap;
+  max-width: 70px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
-/* Service Cycle FSM States */
+/* Service Cycle FSM States - Cyan/Teal palette */
 .state-badge.service-battery-issued {
-  background: var(--success-soft);
-  color: var(--success);
+  background: var(--accent-soft);
+  color: var(--accent);
 }
 
 .state-badge.service-wait-battery {
-  background: rgba(240, 165, 0, 0.15);
-  color: #f0a500;
+  background: rgba(147, 112, 219, 0.15);
+  color: #9370db;
 }
 
 .state-badge.service-battery-returned {
-  background: var(--accent-soft);
-  color: var(--accent);
+  background: rgba(100, 149, 237, 0.15);
+  color: #6495ed;
 }
 
 .state-badge.service-battery-lost {
@@ -2519,7 +2553,7 @@ html.theme-transition *::after {
   color: var(--text-tertiary);
 }
 
-/* Payment Cycle FSM States */
+/* Payment Cycle FSM States - Green/Orange/Red palette */
 .state-badge.payment-current {
   background: var(--success-soft);
   color: var(--success);


### PR DESCRIPTION
Enhance the display of Payment and Service states by adding labels, ensuring distinct color palettes, and resolving overflow issues.

Previously, state badges lacked context, had inconsistent coloring, and could overflow. This PR introduces explicit 'Service' and 'Payment' labels, assigns unique color schemes (cyan/teal for service, green/orange/red for payment), and implements styling to prevent text overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0c4c3c4-434b-46b6-b710-873876d2b900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0c4c3c4-434b-46b6-b710-873876d2b900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

