### PR TITLE
Enable V-Console and filter device logs

### DIFF
--- a/src/app/(mobile)/assets/ble-devices/DeviceDetailView.tsx
+++ b/src/app/(mobile)/assets/ble-devices/DeviceDetailView.tsx
@@ -165,7 +165,6 @@ const DeviceDetailView: React.FC<DeviceDetailProps> = ({
       (data: any, error: any) => {
         setLoadingStates((prev) => ({ ...prev, [characteristicUuid]: false }));
         if (data) {
-          console.info(data.realVal, "Value of Field");
           toast.success(`${name} read successfully`);
           setUpdatedValues((prev) => ({
             ...prev,
@@ -201,15 +200,6 @@ const DeviceDetailView: React.FC<DeviceDetailProps> = ({
       return;
     }
     
-    console.info({
-      action: "write",
-      serviceUuid: activeService.uuid,
-      characteristicUuid: activeCharacteristic.uuid,
-      macAddress: device.macAddress,
-      name: device.name,
-      value: value,
-    });
-    
     // Set loading state
     setLoadingStates((prev) => ({ ...prev, [activeCharacteristic.uuid]: true }));
     
@@ -220,7 +210,6 @@ const DeviceDetailView: React.FC<DeviceDetailProps> = ({
       device.macAddress,
       (responseData: any) => {
         setLoadingStates((prev) => ({ ...prev, [activeCharacteristic.uuid]: false }));
-        console.info({ writeResponse: responseData });
         
         // Parse response to check if write succeeded
         let writeSuccess = false;

--- a/src/app/(mobile)/assets/ble-devices/page.tsx
+++ b/src/app/(mobile)/assets/ble-devices/page.tsx
@@ -459,14 +459,11 @@ const AppContainer = () => {
   console.error(detectedDevices, "Detected Devices-----468");
 
   const startQrCodeScan = () => {
-    console.info("Start QR Code Scan");
     if (window.WebViewJavascriptBridge) {
       window.WebViewJavascriptBridge.callHandler(
         "startQrCodeScan",
         999,
-        (responseData) => {
-          console.info(responseData);
-        }
+        () => {}
       );
     }
   };
@@ -485,7 +482,6 @@ const AppContainer = () => {
     initServiceBleData(data);
   };
 
-  console.info(isMqttConnected, "Is Mqtt Connected");
   useEffect(() => {
     if (progress === 100 && attributeList.length > 0) {
       setIsConnecting(false); // Connection process complete
@@ -657,7 +653,7 @@ const AppContainer = () => {
       },
     };
 
-    console.info(dataToPublish, `Data to Publish for ${serviceType} service`);
+    console.info(`[BLE Device] Individual Service Data - ${serviceType}:`, dataToPublish);
     // toast(`Preparing to publish ${serviceType} data`, {
     //   duration: 2000, // Show for 2 seconds
     // });
@@ -666,10 +662,7 @@ const AppContainer = () => {
       window.WebViewJavascriptBridge.callHandler(
         "mqttPublishMsg",
         JSON.stringify(dataToPublish),
-        (response) => {
-          console.info(`MQTT Response for ${serviceType}:`, response);
-          // toast.success(t('{service} data published successfully', { service: serviceType }));
-        }
+        () => {}
       );
     } catch (error) {
       console.error(`Error publishing ${serviceType} data:`, error);
@@ -750,7 +743,27 @@ const AppContainer = () => {
       }, index * 500); // 500ms delay between each publish
     });
 
-    console.info("Publishing services:", availableServices);
+    // Build combined device details object for logging
+    const allDeviceDetails: { [key: string]: any } = {};
+    availableServices.forEach((serviceType) => {
+      const serviceNameEnum = `${serviceType}_SERVICE`;
+      const service = attributeList.find(
+        (s: any) => s.serviceNameEnum === serviceNameEnum
+      );
+      if (service) {
+        allDeviceDetails[serviceType] = service.characteristicList.reduce(
+          (acc: any, char: any) => {
+            if (char.realVal !== null && char.realVal !== undefined) {
+              acc[char.name] = char.realVal;
+            }
+            return acc;
+          },
+          {}
+        );
+      }
+    });
+
+    console.info("[BLE Device] All Device Details Combined:", allDeviceDetails);
   };
 
   const bleLoadingSteps = [

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,12 +26,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
 
-  // useEffect(() => {
-  //   import('vconsole').then((module) => {
-  //     const VConsole = module.default;
-  //     new VConsole();
-  //   });
-  // }, []);
+  useEffect(() => {
+    import('vconsole').then((module) => {
+      const VConsole = module.default;
+      new VConsole();
+    });
+  }, []);
   return (
     <html lang="en">
       <body


### PR DESCRIPTION
Enable V-Console and refine `console.info()` logs to only display individual and combined BLE device details.

---
<a href="https://cursor.com/background-agent?bcId=bc-4af9cc7c-18f3-45e0-9b32-14d8f45578f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4af9cc7c-18f3-45e0-9b32-14d8f45578f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

