### PR TITLE
Calculate device power usage from dta

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -267,8 +267,11 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
     });
   }, []);
 
-  // Extract energy from DTA service data (rcap * pckv / 100)
-  const populateEnergyFromDta = useCallback((serviceData: any): number | null => {
+  // Extract energy from DTA service data
+  // rcap = Remaining Capacity in Whs (already in Watt-hours!)
+  // fccp = Full Charge Capacity in Whs (for calculating charge percentage)
+  // Returns { energy: Wh, fullCapacity: Wh, chargePercent: % } or null on failure
+  const populateEnergyFromDta = useCallback((serviceData: any): { energy: number; fullCapacity: number; chargePercent: number } | null => {
     if (!serviceData || !Array.isArray(serviceData.characteristicList)) {
       console.warn('Invalid DTA service data for energy calculation');
       return null;
@@ -281,39 +284,52 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
       return char?.realVal ?? null;
     };
 
-    const rcapRaw = getCharValue('rcap');
-    const pckvRaw = getCharValue('pckv');
+    const rcapRaw = getCharValue('rcap');  // Remaining Capacity in Whs
+    const fccpRaw = getCharValue('fccp');  // Full Charge Capacity in Whs
+    const rsocRaw = getCharValue('rsoc');  // Relative State of Charge (%)
 
     const rcap = rcapRaw !== null ? parseFloat(rcapRaw) : NaN;
-    const pckv = pckvRaw !== null ? parseFloat(pckvRaw) : NaN;
+    const fccp = fccpRaw !== null ? parseFloat(fccpRaw) : NaN;
+    const rsoc = rsocRaw !== null ? parseFloat(rsocRaw) : NaN;
 
-    if (!Number.isFinite(rcap) || !Number.isFinite(pckv)) {
-      console.warn('Unable to parse rcap/pckv values from DTA service', {
+    if (!Number.isFinite(rcap)) {
+      console.warn('Unable to parse rcap (Remaining Capacity) from DTA service', {
         rcapRaw,
-        pckvRaw,
       });
       return null;
     }
 
-    // Energy = (rcap * pckv) / 100 in Wh
-    const computedEnergy = (rcap * pckv) / 100;
+    // rcap is ALREADY in Watt-hours! No calculation needed.
+    const energy = rcap;
 
-    if (!Number.isFinite(computedEnergy)) {
-      console.warn('Computed energy is not a finite number', {
-        rcap,
-        pckv,
-        computedEnergy,
-      });
-      return null;
+    // Calculate charge percentage from rcap/fccp, fallback to rsoc if fccp unavailable
+    let chargePercent: number;
+    if (Number.isFinite(fccp) && fccp > 0) {
+      chargePercent = Math.round((rcap / fccp) * 100);
+    } else if (Number.isFinite(rsoc)) {
+      chargePercent = Math.round(rsoc);
+    } else {
+      // Default to 0 if we can't calculate
+      chargePercent = 0;
     }
 
-    console.info('Energy computed from DTA service:', {
-      rcap,
-      pckv,
-      energy: computedEnergy,
+    // Clamp charge percent to 0-100
+    chargePercent = Math.max(0, Math.min(100, chargePercent));
+
+    console.info('Energy extracted from DTA service:', {
+      rcap_Wh: rcap,
+      fccp_Wh: fccp,
+      rsoc_percent: rsoc,
+      computed_energy_Wh: energy,
+      computed_energy_kWh: energy / 1000,
+      computed_chargePercent: chargePercent,
     });
 
-    return Math.round(computedEnergy * 100) / 100; // Round to 2 decimal places
+    return {
+      energy: Math.round(energy * 100) / 100, // Round to 2 decimal places (Wh)
+      fullCapacity: Number.isFinite(fccp) ? Math.round(fccp * 100) / 100 : 0,
+      chargePercent,
+    };
   }, []);
 
   // Handle matching QR code to detected BLE device and initiate connection
@@ -1029,8 +1045,9 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
           if (parsedData?.serviceNameEnum === "DTA_SERVICE") {
             console.info("DTA service data received:", parsedData);
             
-            // Calculate energy from DTA data
-            const energy = populateEnergyFromDtaRef.current(parsedData);
+            // Extract energy data from DTA service
+            // Returns { energy: Wh, fullCapacity: Wh, chargePercent: % } or null
+            const energyData = populateEnergyFromDtaRef.current(parsedData);
             const scannedBatteryId = pendingBatteryQrCodeRef.current;
             const scanType = pendingBatteryScanTypeRef.current;
             
@@ -1049,38 +1066,35 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
               connectedDevice: null,
             }));
             
-            if (energy !== null && scannedBatteryId) {
-              console.info(`Battery energy read: ${energy} Wh for ${scanType}`);
-              
-              // Calculate charge level percentage (assume 1000Wh max capacity for now)
-              // This can be refined based on actual battery specs
-              const chargeLevel = Math.min(Math.round((energy / 1000) * 100), 100);
+            if (energyData !== null && scannedBatteryId) {
+              const { energy, chargePercent } = energyData;
+              console.info(`Battery energy read: ${energy} Wh (${(energy / 1000).toFixed(3)} kWh) at ${chargePercent}% for ${scanType}`);
               
               if (scanType === 'old_battery') {
-                // Create old battery data with actual energy
+                // Create old battery data with actual energy from rcap (in Wh)
                 const oldBattery: BatteryData = {
                   id: scannedBatteryId,
                   shortId: String(scannedBatteryId).slice(-6),
-                  chargeLevel: chargeLevel,
-                  energy: energy,
+                  chargeLevel: chargePercent,
+                  energy: energy, // rcap in Wh
                   macAddress: sessionStorage.getItem("connectedDeviceMac") || undefined,
                 };
                 
                 setSwapData(prev => ({ ...prev, oldBattery }));
                 setCurrentStep(3);
-                toast.success(`Old battery scanned: ${(energy / 1000).toFixed(3)} kWh`);
+                toast.success(`Old battery scanned: ${(energy / 1000).toFixed(3)} kWh (${chargePercent}%)`);
               } else if (scanType === 'new_battery') {
                 // Create new battery data and calculate differential
                 const newBattery: BatteryData = {
                   id: scannedBatteryId,
                   shortId: String(scannedBatteryId).slice(-6),
-                  chargeLevel: chargeLevel,
-                  energy: energy,
+                  chargeLevel: chargePercent,
+                  energy: energy, // rcap in Wh
                   macAddress: sessionStorage.getItem("connectedDeviceMac") || undefined,
                 };
                 
                 // Calculate energy difference and cost using actual energy values
-                // Energy from BLE is in Wh, but rate is per kWh - convert Wh to kWh
+                // Energy from BLE (rcap) is in Wh, rate is per kWh - convert Wh to kWh
                 setSwapData(prev => {
                   const oldEnergy = prev.oldBattery?.energy || 0;
                   const energyDiffWh = energy - oldEnergy; // Energy diff in Wh
@@ -1091,7 +1105,9 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
                   
                   console.info('Energy differential calculated:', {
                     oldEnergyWh: oldEnergy,
+                    oldEnergyKwh: oldEnergy / 1000,
                     newEnergyWh: energy,
+                    newEnergyKwh: energy / 1000,
                     energyDiffWh,
                     energyDiffKwh,
                     ratePerKwh: rate,
@@ -1107,10 +1123,10 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
                 });
                 
                 setCurrentStep(4);
-                toast.success(`New battery scanned: ${(energy / 1000).toFixed(3)} kWh`);
+                toast.success(`New battery scanned: ${(energy / 1000).toFixed(3)} kWh (${chargePercent}%)`);
               }
             } else {
-              console.warn("Could not calculate energy from DTA data or missing battery ID");
+              console.warn("Could not extract energy from DTA data or missing battery ID");
               toast.error('Could not read battery energy. Please try again.');
             }
             

--- a/src/app/(mobile)/attendant/attendant/components/types.ts
+++ b/src/app/(mobile)/attendant/attendant/components/types.ts
@@ -33,7 +33,7 @@ export interface BatteryData {
   id: string;
   shortId: string;
   chargeLevel: number; // Charge percentage (0-100) from rsoc or calculated from rcap/fccp
-  energy: number; // Remaining energy in Wh from BLE DTA service (rcap field - already in Watt-hours)
+  energy: number; // Remaining energy in Wh = (rcap_mAh × pckv_mV) / 1,000,000
   macAddress?: string; // BLE MAC address used for connection
 }
 

--- a/src/app/(mobile)/attendant/attendant/components/types.ts
+++ b/src/app/(mobile)/attendant/attendant/components/types.ts
@@ -32,8 +32,8 @@ export interface FlowError {
 export interface BatteryData {
   id: string;
   shortId: string;
-  chargeLevel: number;
-  energy: number; // Energy in Wh computed from BLE (rcap * pckv / 100)
+  chargeLevel: number; // Charge percentage (0-100) from rsoc or calculated from rcap/fccp
+  energy: number; // Remaining energy in Wh from BLE DTA service (rcap field - already in Watt-hours)
   macAddress?: string; // BLE MAC address used for connection
 }
 


### PR DESCRIPTION
Corrects battery energy calculation from DTA service by using `rcap` (Remaining Capacity in Wh) directly, as it was previously multiplied incorrectly.

The previous implementation incorrectly calculated energy using `(rcap * pckv) / 100`. The `rcap` field from the DTA service already represents Remaining Capacity in Watt-hours, making the multiplication by `pckv` (Pack Voltage in mV) and subsequent division by 100 erroneous and resulting in vastly inflated energy values. This PR updates the logic to use `rcap` directly as Wh and converts to kWh where required, also extracting `fullCapacity` and `chargePercent` for better accuracy.

---
<a href="https://cursor.com/background-agent?bcId=bc-8a289e88-f93b-4992-8c17-bf4b838a2548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8a289e88-f93b-4992-8c17-bf4b838a2548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

