### PR TITLE
Verify and fix payment confirmation and qr code flow

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/ActionBar.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/ActionBar.tsx
@@ -79,7 +79,8 @@ export default function ActionBar({ currentStep, onBack, onMainAction, isLoading
   const config = getStepConfig(currentStep, inputMode);
 
   // Don't show the action bar button for step 1 in manual mode - button is in the form
-  const hideMainButton = currentStep === 1 && inputMode === 'manual';
+  // Don't show for step 5 either - Step5Payment has its own action buttons for both scan and manual modes
+  const hideMainButton = (currentStep === 1 && inputMode === 'manual') || currentStep === 5;
 
   return (
     <div className="action-bar">

--- a/src/app/(mobile)/attendant/attendant/components/CustomerStatePanel.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/CustomerStatePanel.tsx
@@ -77,22 +77,18 @@ export default function CustomerStatePanel({ customer, visible }: CustomerStateP
               <div className="state-customer-name">{customer.name}</div>
               <div className="state-plan-row">
                 <span className="state-plan-name">{customer.subscriptionType}</span>
-                {customer.serviceState && (
-                  <span className={`state-badge-group service`}>
-                    <span className="state-badge-label">Service</span>
+                <div className="state-badges">
+                  {customer.serviceState && (
                     <span className={`state-badge ${serviceConfig.className}`}>
                       {serviceConfig.shortLabel}
                     </span>
-                  </span>
-                )}
-                {customer.paymentState && (
-                  <span className={`state-badge-group payment`}>
-                    <span className="state-badge-label">Payment</span>
+                  )}
+                  {customer.paymentState && (
                     <span className={`state-badge ${paymentConfig.className}`}>
                       {paymentConfig.shortLabel}
                     </span>
-                  </span>
-                )}
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step5Payment.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step5Payment.tsx
@@ -16,7 +16,14 @@ export default function Step5Payment({ swapData, onConfirmPayment, onManualPayme
 
   const handleManualConfirm = () => {
     if (paymentId.trim()) {
-      onManualPayment(paymentId);
+      onManualPayment(paymentId.trim());
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && paymentId.trim() && !isProcessing) {
+      e.preventDefault();
+      handleManualConfirm();
     }
   };
 
@@ -90,6 +97,7 @@ export default function Step5Payment({ swapData, onConfirmPayment, onManualPayme
                   placeholder="e.g. TXN-892741 or M-PESA code"
                   value={paymentId}
                   onChange={(e) => setPaymentId(e.target.value)}
+                  onKeyDown={handleKeyDown}
                   autoComplete="off"
                 />
               </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2596,7 +2596,15 @@ html.theme-transition *::after {
   flex-shrink: 1;
 }
 
-/* State badge groups - contains label + badge */
+/* State badges container - simple side-by-side layout */
+.state-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+/* State badge groups - contains label + badge (legacy) */
 .state-badge-group {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Enable manual payment confirmation on Enter in Step 5 and simplify customer state badge display.

The manual payment flow in Step 5 previously incorrectly triggered the scanner instead of confirming payment via Odoo. This PR adds Enter key handling to trigger the correct manual payment confirmation and hides the redundant ActionBar button for this step. Additionally, the "Service" and "Payment" labels were removed from the customer state badges to simplify the UI, displaying only the badges side-by-side.

---
<a href="https://cursor.com/background-agent?bcId=bc-790138d6-f403-44a4-9130-6993fc74e819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-790138d6-f403-44a4-9130-6993fc74e819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

