### PR TITLE
Fix qr code as subscription code

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -435,13 +435,15 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
       parsedData = qrCodeData;
     }
 
+    // If the QR code is a plain string (not JSON object), treat it as the subscription code directly
+    // This allows scanning a QR code that IS the subscription code (e.g., "SUB-8847-KE")
     const normalizedData: any = {
       customer_id: typeof parsedData === 'object'
         ? parsedData.customer_id || parsedData.customerId || parsedData.customer?.id || qrCodeData
         : qrCodeData,
       subscription_code: typeof parsedData === 'object'
         ? parsedData.subscription_code || parsedData.subscriptionCode || parsedData.subscription?.code
-        : undefined,
+        : qrCodeData, // Plain string QR code IS the subscription code
       name: typeof parsedData === 'object'
         ? parsedData.name || parsedData.customer_name
         : undefined,

--- a/src/app/(mobile)/attendant/attendant/swap.tsx
+++ b/src/app/(mobile)/attendant/attendant/swap.tsx
@@ -355,6 +355,8 @@ const deriveCustomerTypeFromPayload = (payload?: any) => {
         parsedData = qrCodeData;
       }
 
+      // If the QR code is a plain string (not JSON object), treat it as the subscription code directly
+      // This allows scanning a QR code that IS the subscription code (e.g., "SUB-8847-KE")
       const normalizedData: any = {
         customer_id:
           typeof parsedData === "object"
@@ -368,7 +370,7 @@ const deriveCustomerTypeFromPayload = (payload?: any) => {
             ? parsedData.subscription_code ||
               parsedData.subscriptionCode ||
               parsedData.subscription?.code
-            : undefined,
+            : qrCodeData, // Plain string QR code IS the subscription code
         product_name:
           typeof parsedData === "object"
             ? parsedData.product_name ||


### PR DESCRIPTION
Allow plain string QR codes to be used directly as subscription codes to fix "missing subscription code" error.

Previously, if a QR code contained only a subscription code as a plain string (e.g., "SUB-8847-KE"), the application would attempt to parse it as JSON. Upon failure, it would incorrectly set the `subscription_code` to `undefined`, leading to an error. This change ensures that if the QR code data is a plain string, it is used directly as the subscription code.

---
<a href="https://cursor.com/background-agent?bcId=bc-db456504-8dec-4943-a488-aa56838f5b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-db456504-8dec-4943-a488-aa56838f5b97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

