### PR TITLE
Update scanning page logo to show scanning not started

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/ScannerArea.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/ScannerArea.tsx
@@ -6,23 +6,21 @@ interface ScannerAreaProps {
   onClick: () => void;
   type?: 'qr' | 'battery';
   size?: 'normal' | 'small';
-  isScanning?: boolean;
 }
 
-export default function ScannerArea({ onClick, type = 'qr', size = 'normal', isScanning = false }: ScannerAreaProps) {
+export default function ScannerArea({ onClick, type = 'qr', size = 'normal' }: ScannerAreaProps) {
   const sizeStyle = size === 'small' 
     ? { width: '120px', height: '120px', margin: '12px auto' } 
     : {};
 
   return (
-    <div className={`scanner-area ${isScanning ? 'scanning' : ''}`} onClick={onClick} style={sizeStyle}>
+    <div className="scanner-area" onClick={onClick} style={sizeStyle}>
       <div className="scanner-frame">
         <div className="scanner-corners">
           <div className="scanner-corner-bl"></div>
           <div className="scanner-corner-br"></div>
         </div>
-        {/* Scanner line - only visible and animated when actively scanning */}
-        {isScanning && <div className="scanner-line"></div>}
+        {/* No animated scanner line - it was misleading users into thinking scanning was active */}
         <div className="scanner-icon">
           {type === 'qr' ? (
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -38,12 +36,10 @@ export default function ScannerArea({ onClick, type = 'qr', size = 'normal', isS
             </svg>
           )}
         </div>
-        {/* Tap to scan prompt - only visible when NOT scanning */}
-        {!isScanning && (
-          <div className="scanner-tap-prompt">
-            <span>Tap to scan</span>
-          </div>
-        )}
+        {/* Clear prompt so users know to tap */}
+        <div className="scanner-tap-prompt">
+          <span>Tap to scan</span>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(mobile)/attendant/attendant/components/ScannerArea.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/ScannerArea.tsx
@@ -6,21 +6,23 @@ interface ScannerAreaProps {
   onClick: () => void;
   type?: 'qr' | 'battery';
   size?: 'normal' | 'small';
+  isScanning?: boolean;
 }
 
-export default function ScannerArea({ onClick, type = 'qr', size = 'normal' }: ScannerAreaProps) {
+export default function ScannerArea({ onClick, type = 'qr', size = 'normal', isScanning = false }: ScannerAreaProps) {
   const sizeStyle = size === 'small' 
     ? { width: '120px', height: '120px', margin: '12px auto' } 
     : {};
 
   return (
-    <div className="scanner-area" onClick={onClick} style={sizeStyle}>
+    <div className={`scanner-area ${isScanning ? 'scanning' : ''}`} onClick={onClick} style={sizeStyle}>
       <div className="scanner-frame">
         <div className="scanner-corners">
           <div className="scanner-corner-bl"></div>
           <div className="scanner-corner-br"></div>
         </div>
-        <div className="scanner-line"></div>
+        {/* Scanner line - only visible and animated when actively scanning */}
+        {isScanning && <div className="scanner-line"></div>}
         <div className="scanner-icon">
           {type === 'qr' ? (
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -36,6 +38,12 @@ export default function ScannerArea({ onClick, type = 'qr', size = 'normal' }: S
             </svg>
           )}
         </div>
+        {/* Tap to scan prompt - only visible when NOT scanning */}
+        {!isScanning && (
+          <div className="scanner-tap-prompt">
+            <span>Tap to scan</span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1249,6 +1249,38 @@ html.theme-transition *::after {
   stroke-width: 1;
 }
 
+/* Tap to scan prompt - shown when scanner is idle */
+.scanner-tap-prompt {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--accent-soft);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 4px 10px;
+  border-radius: var(--radius-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  animation: tapPromptPulse 2s ease-in-out infinite;
+}
+
+@keyframes tapPromptPulse {
+  0%, 100% { opacity: 0.7; }
+  50% { opacity: 1; }
+}
+
+/* Active scanning state */
+.scanner-area.scanning .scanner-frame {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+}
+
+.scanner-area.scanning .scanner-icon {
+  opacity: 0.5;
+}
+
 .scan-hint {
   display: flex;
   align-items: center;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1249,7 +1249,7 @@ html.theme-transition *::after {
   stroke-width: 1;
 }
 
-/* Tap to scan prompt - shown when scanner is idle */
+/* Tap to scan prompt - clear call-to-action for users */
 .scanner-tap-prompt {
   position: absolute;
   bottom: 20px;
@@ -1263,22 +1263,6 @@ html.theme-transition *::after {
   border-radius: var(--radius-sm);
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  animation: tapPromptPulse 2s ease-in-out infinite;
-}
-
-@keyframes tapPromptPulse {
-  0%, 100% { opacity: 0.7; }
-  50% { opacity: 1; }
-}
-
-/* Active scanning state */
-.scanner-area.scanning .scanner-frame {
-  border-color: var(--accent);
-  box-shadow: var(--shadow-glow);
-}
-
-.scanner-area.scanning .scanner-icon {
-  opacity: 0.5;
 }
 
 .scan-hint {


### PR DESCRIPTION
Conditionally render the scanner animation and add a "Tap to scan" prompt to accurately reflect the scanning state.

Previously, the scanner line animation ran continuously, giving the misleading impression that scanning was active even before the user tapped to initiate it. This change ensures the UI clearly indicates when scanning is idle and when it's actively happening.

---
<a href="https://cursor.com/background-agent?bcId=bc-2179a99d-5ec5-4c72-bec5-272e1d833267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2179a99d-5ec5-4c72-bec5-272e1d833267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

