### PR TITLE
Optimize payment confirmation page layout

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -2180,7 +2180,8 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
       case 5:
         return (
           <Step5Payment 
-            swapData={swapData} 
+            swapData={swapData}
+            customerData={customerData}
             onConfirmPayment={handleConfirmPayment}
             onManualPayment={handleManualPayment}
             isProcessing={isProcessing || paymentAndServiceStatus === 'pending'}
@@ -2220,10 +2221,10 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
         flowError={flowError}
       />
 
-      {/* Customer State Panel - Shows after customer identified */}
+      {/* Customer State Panel - Shows after customer identified, hidden on payment/success steps */}
       <CustomerStatePanel 
         customer={customerData} 
-        visible={currentStep > 1}
+        visible={currentStep > 1 && currentStep < 5}
       />
 
       {/* Main Content */}

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step5Payment.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step5Payment.tsx
@@ -1,16 +1,17 @@
 'use client';
 
 import React, { useState } from 'react';
-import { SwapData } from '../types';
+import { SwapData, CustomerData, getInitials } from '../types';
 
 interface Step5Props {
   swapData: SwapData;
+  customerData?: CustomerData | null;
   onConfirmPayment: () => void;
   onManualPayment: (paymentId: string) => void;
   isProcessing: boolean;
 }
 
-export default function Step5Payment({ swapData, onConfirmPayment, onManualPayment, isProcessing }: Step5Props) {
+export default function Step5Payment({ swapData, customerData, onConfirmPayment, onManualPayment, isProcessing }: Step5Props) {
   const [inputMode, setInputMode] = useState<'scan' | 'manual'>('scan');
   const [paymentId, setPaymentId] = useState('');
 
@@ -29,12 +30,15 @@ export default function Step5Payment({ swapData, onConfirmPayment, onManualPayme
 
   return (
     <div className="screen active">
-      {/* Amount to Collect */}
-      <div className="cost-card" style={{ marginBottom: '8px' }}>
-        <div className="cost-total" style={{ marginTop: 0 }}>
-          <span className="cost-total-label">Amount to Collect</span>
-          <span className="cost-total-value">KES {swapData.cost}</span>
-        </div>
+      {/* Compact Customer + Amount Header */}
+      <div className="payment-header-compact">
+        {customerData && (
+          <div className="payment-customer-mini">
+            <div className="payment-customer-avatar">{getInitials(customerData.name)}</div>
+            <span className="payment-customer-name">{customerData.name}</span>
+          </div>
+        )}
+        <div className="payment-amount-large">KES {swapData.cost}</div>
       </div>
 
       <div className="payment-scan">
@@ -81,13 +85,10 @@ export default function Step5Payment({ swapData, onConfirmPayment, onManualPayme
               </div>
             </div>
             
-            <div className="payment-amount">KES {swapData.cost.toFixed(2)}</div>
             <div className="payment-status">Tap to scan customer QR</div>
           </div>
         ) : (
-          <div className="payment-input-mode">
-            <p className="payment-subtitle">Enter payment transaction ID</p>
-            
+          <div className="payment-input-mode payment-input-mode-manual">
             <div className="manual-entry-form">
               <div className="form-group" style={{ marginBottom: 0 }}>
                 <label className="form-label">Payment / Transaction ID</label>
@@ -114,8 +115,7 @@ export default function Step5Payment({ swapData, onConfirmPayment, onManualPayme
               </button>
             </div>
             
-            <div className="payment-amount" style={{ marginTop: '8px' }}>KES {swapData.cost.toFixed(2)}</div>
-            <p className="scan-hint" style={{ marginTop: '4px' }}>
+            <p className="scan-hint" style={{ marginTop: '8px' }}>
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="10"/>
                 <path d="M12 16v-4M12 8h.01"/>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1768,6 +1768,65 @@ html.theme-transition *::after {
   color: var(--accent);
 }
 
+/* Compact Payment Header - Shows customer and amount when full panel is hidden */
+.payment-header-compact {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+  background: var(--bg-secondary);
+  border-radius: var(--radius-lg);
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+}
+
+.payment-customer-mini {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.payment-customer-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent), var(--accent-hover));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+.payment-customer-name {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.payment-amount-large {
+  font-family: 'DM Mono', monospace;
+  font-size: 20px;
+  font-weight: 700;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+/* Manual entry mode optimizations for keyboard visibility */
+.payment-input-mode-manual {
+  padding-bottom: 0;
+}
+
+.payment-input-mode-manual .manual-entry-form {
+  margin-bottom: 0;
+}
+
 /* Payment Scan */
 .payment-scan {
   text-align: center;


### PR DESCRIPTION
Hide the full customer info panel and add a compact header on the payment page to improve space when the keyboard is active.

The payment confirmation page was cramped on mobile when the virtual keyboard appeared for manual payment entry. The `CustomerStatePanel` occupied a significant portion of the screen, leaving little room for payment inputs. This PR hides the large panel on the payment and success steps, replacing it with a minimal, single-line header showing only the customer name and amount, freeing up crucial screen real estate.

---
<a href="https://cursor.com/background-agent?bcId=bc-37824c54-cbeb-4177-8cc8-d7cb725fbff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37824c54-cbeb-4177-8cc8-d7cb725fbff5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

