### PR TITLE
Log individual ble services on detail view

### DIFF
--- a/src/app/(mobile)/assets/ble-devices/DeviceDetailView.tsx
+++ b/src/app/(mobile)/assets/ble-devices/DeviceDetailView.tsx
@@ -165,7 +165,6 @@ const DeviceDetailView: React.FC<DeviceDetailProps> = ({
       (data: any, error: any) => {
         setLoadingStates((prev) => ({ ...prev, [characteristicUuid]: false }));
         if (data) {
-          console.info(data.realVal, "Value of Field");
           toast.success(`${name} read successfully`);
           setUpdatedValues((prev) => ({
             ...prev,
@@ -201,15 +200,6 @@ const DeviceDetailView: React.FC<DeviceDetailProps> = ({
       return;
     }
     
-    console.info({
-      action: "write",
-      serviceUuid: activeService.uuid,
-      characteristicUuid: activeCharacteristic.uuid,
-      macAddress: device.macAddress,
-      name: device.name,
-      value: value,
-    });
-    
     // Set loading state
     setLoadingStates((prev) => ({ ...prev, [activeCharacteristic.uuid]: true }));
     
@@ -220,7 +210,6 @@ const DeviceDetailView: React.FC<DeviceDetailProps> = ({
       device.macAddress,
       (responseData: any) => {
         setLoadingStates((prev) => ({ ...prev, [activeCharacteristic.uuid]: false }));
-        console.info({ writeResponse: responseData });
         
         // Parse response to check if write succeeded
         let writeSuccess = false;

--- a/src/app/(mobile)/assets/ble-devices/page.tsx
+++ b/src/app/(mobile)/assets/ble-devices/page.tsx
@@ -383,6 +383,9 @@ const AppContainer = () => {
       "bleInitServiceDataOnCompleteCallBack",
       (data: string, resp: any) => {
         const parsedData = JSON.parse(data);
+        // Log individual service content when loaded
+        const serviceName = parsedData.serviceNameEnum?.replace('_SERVICE', '') || 'Unknown';
+        console.info(`[${serviceName} Service]`, parsedData);
         setServiceAttrList((prev: any) => {
           if (!prev || prev.length === 0) return [parsedData];
           const idx = prev.findIndex((s: any) => s.uuid === parsedData.uuid);
@@ -459,14 +462,11 @@ const AppContainer = () => {
   console.error(detectedDevices, "Detected Devices-----468");
 
   const startQrCodeScan = () => {
-    console.info("Start QR Code Scan");
     if (window.WebViewJavascriptBridge) {
       window.WebViewJavascriptBridge.callHandler(
         "startQrCodeScan",
         999,
-        (responseData) => {
-          console.info(responseData);
-        }
+        () => {}
       );
     }
   };
@@ -485,7 +485,6 @@ const AppContainer = () => {
     initServiceBleData(data);
   };
 
-  console.info(isMqttConnected, "Is Mqtt Connected");
   useEffect(() => {
     if (progress === 100 && attributeList.length > 0) {
       setIsConnecting(false); // Connection process complete
@@ -657,7 +656,6 @@ const AppContainer = () => {
       },
     };
 
-    console.info(dataToPublish, `Data to Publish for ${serviceType} service`);
     // toast(`Preparing to publish ${serviceType} data`, {
     //   duration: 2000, // Show for 2 seconds
     // });
@@ -666,10 +664,7 @@ const AppContainer = () => {
       window.WebViewJavascriptBridge.callHandler(
         "mqttPublishMsg",
         JSON.stringify(dataToPublish),
-        (response) => {
-          console.info(`MQTT Response for ${serviceType}:`, response);
-          // toast.success(t('{service} data published successfully', { service: serviceType }));
-        }
+        () => {}
       );
     } catch (error) {
       console.error(`Error publishing ${serviceType} data:`, error);
@@ -750,7 +745,6 @@ const AppContainer = () => {
       }, index * 500); // 500ms delay between each publish
     });
 
-    console.info("Publishing services:", availableServices);
   };
 
   const bleLoadingSteps = [


### PR DESCRIPTION
Add `console.info()` to log individual BLE services on the detail view and remove all other `console.info()` statements.

The change ensures that only relevant service data is logged to the console, as per user request, by removing various other `console.info()` calls that were cluttering the output.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d200d3e-9a3e-48f9-b2ba-9c4f53923dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d200d3e-9a3e-48f9-b2ba-9c4f53923dd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

