### PR TITLE
Fix premature attendant workflow retries

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -141,6 +141,8 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
   
   // BLE retry state
   const bleRetryCountRef = useRef<number>(0);
+  // Track whether connection was successful - prevents retrying when already connected but initializing services
+  const isConnectionSuccessfulRef = useRef<boolean>(false);
   const MAX_BLE_RETRIES = 3;
   const BLE_CONNECTION_TIMEOUT = 15000; // 15 seconds for connection
   const BLE_DATA_READ_TIMEOUT = 20000; // 20 seconds for data reading
@@ -239,6 +241,7 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
     pendingBatteryQrCodeRef.current = null;
     pendingBatteryScanTypeRef.current = null;
     bleRetryCountRef.current = 0;
+    isConnectionSuccessfulRef.current = false;
     
     toast('BLE operation cancelled', { icon: '⚠️' });
   }, [clearBleOperationTimeout, clearScanTimeout]);
@@ -324,6 +327,10 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
     // Clear any existing timeout
     clearBleOperationTimeout();
     
+    // Reset connection success flag - this will be set to true in bleConnectSuccessCallBack
+    // We check this flag before retrying to avoid retrying when already connected
+    isConnectionSuccessfulRef.current = false;
+    
     setBleScanState(prev => ({
       ...prev,
       isConnecting: true,
@@ -333,6 +340,14 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
 
     // Set timeout for connection - if no response within timeout, allow retry or cancel
     bleOperationTimeoutRef.current = setTimeout(() => {
+      // CRITICAL: Check if connection was already successful
+      // This can happen when we've connected but are still waiting for DTA service initialization
+      // In this case, we should NOT retry as we're already connected
+      if (isConnectionSuccessfulRef.current) {
+        console.info('Connection timeout fired but connection was already successful - skipping retry (likely waiting for DTA service)');
+        return;
+      }
+      
       console.warn('BLE connection timed out after', BLE_CONNECTION_TIMEOUT, 'ms');
       
       // Check if we should retry
@@ -349,12 +364,24 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
         
         // Retry connection with exponential backoff
         setTimeout(() => {
+          // Double-check we haven't connected in the meantime
+          if (isConnectionSuccessfulRef.current) {
+            console.info('Connection succeeded during backoff delay - cancelling retry');
+            return;
+          }
+          
           connBleByMacAddress(macAddress, (responseData: string) => {
             console.info('BLE connection retry initiated:', responseData);
           });
           
           // Set new timeout for retry
           bleOperationTimeoutRef.current = setTimeout(() => {
+            // Again check if we connected successfully
+            if (isConnectionSuccessfulRef.current) {
+              console.info('Connection succeeded - skipping further retry timeout handling');
+              return;
+            }
+            
             if (bleRetryCountRef.current >= MAX_BLE_RETRIES) {
               console.error('BLE connection failed after all retries');
               setBleScanState(prev => ({
@@ -379,6 +406,7 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
         pendingBatteryQrCodeRef.current = null;
         pendingBatteryScanTypeRef.current = null;
         bleRetryCountRef.current = 0;
+        isConnectionSuccessfulRef.current = false;
       }
     }, BLE_CONNECTION_TIMEOUT);
 
@@ -1131,6 +1159,11 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
         console.info("BLE connection successful:", macAddress);
         sessionStorage.setItem("connectedDeviceMac", macAddress);
         
+        // CRITICAL: Mark connection as successful FIRST
+        // This prevents the connection timeout from triggering a retry
+        // when we're already connected and waiting for DTA service data
+        isConnectionSuccessfulRef.current = true;
+        
         // Clear connection timeout since we connected successfully
         if (bleOperationTimeoutRef.current) {
           clearTimeout(bleOperationTimeoutRef.current);
@@ -1167,6 +1200,7 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
           scanTypeRef.current = null;
           pendingBatteryQrCodeRef.current = null;
           pendingBatteryScanTypeRef.current = null;
+          isConnectionSuccessfulRef.current = false;
         }, BLE_DATA_READ_TIMEOUT);
         
         // Request DTA service to read energy data
@@ -1194,6 +1228,13 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
           bleOperationTimeoutRef.current = null;
         }
         
+        // If we've already marked connection as successful (e.g., race condition), don't retry
+        if (isConnectionSuccessfulRef.current) {
+          console.info("Connection failure callback received but connection was already successful - ignoring");
+          resp(data);
+          return;
+        }
+        
         // Check if we should auto-retry
         if (bleRetryCountRef.current < MAX_BLE_RETRIES) {
           bleRetryCountRef.current += 1;
@@ -1211,6 +1252,11 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
           
           if (pendingMac) {
             setTimeout(() => {
+              // Double-check we haven't connected successfully in the meantime
+              if (isConnectionSuccessfulRef.current) {
+                console.info("Connection succeeded during retry delay - cancelling retry from failure handler");
+                return;
+              }
               connBleByMacAddress(pendingMac, () => {
                 console.info("BLE retry connection initiated");
               });
@@ -1223,6 +1269,7 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
         
         // All retries failed
         bleRetryCountRef.current = 0;
+        isConnectionSuccessfulRef.current = false;
         
         setBleScanState(prev => ({
           ...prev,
@@ -1364,11 +1411,12 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
               toast.error('Could not read battery energy. Please try again.');
             }
             
-            // Clear pending state
+            // Clear pending state - reset connection flag for next operation
             setIsScanning(false);
             scanTypeRef.current = null;
             pendingBatteryQrCodeRef.current = null;
             pendingBatteryScanTypeRef.current = null;
+            isConnectionSuccessfulRef.current = false;
           }
           
           resp(parsedData);
@@ -1383,6 +1431,7 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
           scanTypeRef.current = null;
           pendingBatteryQrCodeRef.current = null;
           pendingBatteryScanTypeRef.current = null;
+          isConnectionSuccessfulRef.current = false;
           toast.error('Failed to read battery energy data.');
           resp({ success: false, error: String(err) });
         }
@@ -1403,6 +1452,7 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
         scanTypeRef.current = null;
         pendingBatteryQrCodeRef.current = null;
         pendingBatteryScanTypeRef.current = null;
+        isConnectionSuccessfulRef.current = false;
         toast.error('Unable to read battery energy. Please try again.');
       }
     );


### PR DESCRIPTION
Prevent premature retries in the Attendant workflow BLE connection by tracking successful connection state.

The previous implementation would retry connecting even after a successful BLE connection, while the DTA service was still initializing. This caused issues as there is no functionality to disconnect from a device before retrying, leading to the device becoming unreachable. This PR introduces a flag (`isConnectionSuccessfulRef`) to ensure retries only occur when a connection has genuinely failed, not when it's merely waiting for service initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e4f661e-5125-4062-9d68-b78b1714298c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e4f661e-5125-4062-9d68-b78b1714298c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

