### PR TITLE
Improve device connection retry logic

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/types.ts
+++ b/src/app/(mobile)/attendant/attendant/components/types.ts
@@ -54,6 +54,7 @@ export interface BleScanState {
   detectedDevices: BleDevice[];
   connectionProgress: number;
   error: string | null;
+  connectionFailed: boolean; // True when we receive an actual failure callback (not timeout)
 }
 
 export interface SwapData {


### PR DESCRIPTION
Refactor BLE connection retry mechanism to only retry on explicit failures and update UI to show close button only when connection definitively fails.

The previous implementation used timeout-based retries which would trigger even when the BLE device was successfully connected but still undergoing a lengthy initialization process (Step 3). This led to unnecessary retries and a confusing user experience where the 'Cancel' button was always present. This PR ensures retries are only initiated upon an explicit `bleConnectFailCallBack` and the 'Close' button is only shown when all retries are exhausted and a connection failure is confirmed, improving the connection flow and user clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-5234fdea-74e7-476a-b91a-6d8b4cb77981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5234fdea-74e7-476a-b91a-6d8b4cb77981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

