### PR TITLE
Fix old battery scan error message and timeline

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -923,6 +923,9 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
       }
     }
     
+    // Valid new battery detected - clear any previous flow error
+    setFlowError(null);
+    
     // Store the scanned battery ID for later use after BLE connection
     pendingBatteryQrCodeRef.current = scannedBatteryId;
     pendingBatteryScanTypeRef.current = 'new_battery';
@@ -1994,6 +1997,9 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
       toast.error('Bridge not available. Please restart the app.');
       return;
     }
+
+    // Clear any existing flow error when retrying (e.g., after scanning old battery as new by mistake)
+    setFlowError(null);
 
     // Reset BLE connection state but KEEP detected devices (BLE scan is already running from useEffect)
     // This preserves devices that were discovered while user was viewing Step 3


### PR DESCRIPTION
Clears `flowError` state to prevent persistent error messages after a successful new battery scan following a previous error.

When a user attempts to scan an old battery as a new one, an error is correctly displayed. However, if they then scan a *different, valid* new battery, the error message and failed timeline state would persist because the `flowError` was not being cleared upon initiating a new scan or successfully processing a valid battery. This PR ensures the error state is reset, allowing the workflow to proceed correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-23c8b9b3-e0ea-4a32-917a-843a75b5fe8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-23c8b9b3-e0ea-4a32-917a-843a75b5fe8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

