### PR TITLE
Handle bluetooth parsing error with user prompt

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/types.ts
+++ b/src/app/(mobile)/attendant/attendant/components/types.ts
@@ -55,6 +55,7 @@ export interface BleScanState {
   connectionProgress: number;
   error: string | null;
   connectionFailed: boolean; // True when we receive an actual failure callback (not timeout)
+  requiresBluetoothReset: boolean; // True when we get "Bluetooth device not connected" error and user needs to toggle Bluetooth
 }
 
 export interface SwapData {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3547,6 +3547,66 @@ html.theme-transition *::after {
   line-height: 1.5;
 }
 
+/* BLE Progress Icon Warning State */
+.ble-progress-icon-warning {
+  background: linear-gradient(145deg, #fbbf24 0%, #f59e0b 100%);
+  border: 2px solid rgba(251, 191, 36, 0.5);
+  animation: none; /* Remove pulse for warning state */
+}
+
+.ble-progress-icon-warning svg {
+  color: #1c1c1e;
+}
+
+/* BLE Bluetooth Reset Instructions */
+.ble-reset-instructions {
+  margin: 16px 0;
+  padding: 16px;
+  background: rgba(251, 191, 36, 0.1);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+  border-radius: 12px;
+}
+
+.ble-reset-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ble-reset-step {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.ble-reset-step-number {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: linear-gradient(145deg, #fbbf24 0%, #f59e0b 100%);
+  color: #1c1c1e;
+  font-weight: 700;
+  font-size: 13px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* BLE Cancel Button Primary Variant (for Bluetooth reset) */
+.ble-cancel-button-primary {
+  background: linear-gradient(145deg, #3b82f6 0%, #2563eb 100%);
+  border-color: rgba(59, 130, 246, 0.5);
+  color: white;
+}
+
+.ble-cancel-button-primary:hover {
+  background: linear-gradient(145deg, #60a5fa 0%, #3b82f6 100%);
+  border-color: rgba(96, 165, 250, 0.5);
+}
+
 /* Small screen adjustments for BLE progress */
 @media (max-height: 650px) {
   .ble-progress-container {
@@ -3598,5 +3658,25 @@ html.theme-transition *::after {
   .ble-progress-help {
     margin-top: 12px;
     font-size: 11px;
+  }
+  
+  .ble-reset-instructions {
+    margin: 12px 0;
+    padding: 12px;
+  }
+  
+  .ble-reset-steps {
+    gap: 10px;
+  }
+  
+  .ble-reset-step {
+    font-size: 13px;
+    gap: 10px;
+  }
+  
+  .ble-reset-step-number {
+    width: 22px;
+    height: 22px;
+    font-size: 12px;
   }
 }


### PR DESCRIPTION
Implement specific error handling and UI guidance for "Bluetooth device not connected" errors during DTA service operations to resolve a stuck connection issue.

Previously, when the DTA service failed to parse with a "Bluetooth device not connected" error, the app would attempt to refresh the DTA service, which would also fail with "Bluetooth Device Not Found" despite the device being present. This PR catches that specific error, stops the progress modal, and provides clear instructions to the user to toggle Bluetooth, which is a known effective solution for this type of connection loss.

---
<a href="https://cursor.com/background-agent?bcId=bc-ddc47403-73a0-44f7-96c6-a8b9d62c7d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ddc47403-73a0-44f7-96c6-a8b9d62c7d0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

