### PR TITLE
Fix empty battery display in attendant workflow

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/BatterySwapVisual.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/BatterySwapVisual.tsx
@@ -9,11 +9,13 @@ interface BatterySwapVisualProps {
 }
 
 export default function BatterySwapVisual({ oldBattery, newBattery }: BatterySwapVisualProps) {
-  const oldLevel = oldBattery?.chargeLevel || 0;
-  const newLevel = newBattery?.chargeLevel || 100;
+  // Use nullish coalescing (??) to correctly handle 0% charge levels
+  // The || operator treats 0 as falsy, incorrectly showing empty batteries as full
+  const oldLevel = oldBattery?.chargeLevel ?? 0;
+  const newLevel = newBattery?.chargeLevel ?? 0;
   // Convert Wh to kWh for display
-  const oldEnergyKwh = (oldBattery?.energy || 0) / 1000;
-  const newEnergyKwh = (newBattery?.energy || 0) / 1000;
+  const oldEnergyKwh = (oldBattery?.energy ?? 0) / 1000;
+  const newEnergyKwh = (newBattery?.energy ?? 0) / 1000;
 
   return (
     <div className="battery-swap-visual">

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step3NewBattery.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step3NewBattery.tsx
@@ -18,8 +18,8 @@ export default function Step3NewBattery({
   isBleScanning = false,
   detectedDevicesCount = 0,
 }: Step3Props) {
-  const chargeLevel = oldBattery?.chargeLevel || 0;
-  const energyWh = oldBattery?.energy || 0;
+  const chargeLevel = oldBattery?.chargeLevel ?? 0;
+  const energyWh = oldBattery?.energy ?? 0;
   const energyKwh = energyWh / 1000; // Convert to kWh for display
   const batteryClass = getBatteryClass(chargeLevel);
 


### PR DESCRIPTION
Correctly display empty batteries (0 kWh) as empty instead of full in the comparison and review sections.

The logical OR operator (`||`) was incorrectly treating a `chargeLevel` of `0` as falsy, causing it to default to `100` (or `0` for energy values) and misrepresent empty batteries as full. This PR replaces `||` with the nullish coalescing operator (`??`), which only defaults for `null` or `undefined`, ensuring `0` is handled correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-d39bdc59-5007-4091-a65e-5a6eaf04c8bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d39bdc59-5007-4091-a65e-5a6eaf04c8bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

