### PR TITLE
Debug sales workflow javascript bridge error

### DIFF
--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -313,9 +313,15 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
       }
       bridgeInitRef.current = true;
 
-      window.WebViewJavascriptBridge.init((message: any, responseCallback: (response: any) => void) => {
-        responseCallback({ success: true });
-      });
+      // Wrap init in try-catch to handle case where BridgeContext already called init()
+      try {
+        window.WebViewJavascriptBridge.init((message: any, responseCallback: (response: any) => void) => {
+          responseCallback({ success: true });
+        });
+      } catch (err) {
+        // Bridge was already initialized by BridgeContext - this is expected
+        console.info('Bridge already initialized, continuing with handler registration');
+      }
 
       // QR Code result handler
       window.WebViewJavascriptBridge.registerHandler(


### PR DESCRIPTION
Wrap `WebViewJavascriptBridge.init` in `SalesFlow.tsx` with a `try-catch` block to prevent "init called twice" errors.

The `BridgeContext` already initializes the `WebViewJavascriptBridge`. SalesFlow was attempting to re-initialize it, causing a crash. This change aligns SalesFlow with AttendantFlow, which gracefully handles re-initialization attempts.

---
<a href="https://cursor.com/background-agent?bcId=bc-046e6afb-0c95-4ed0-969a-6ce67da29200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-046e6afb-0c95-4ed0-969a-6ce67da29200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

