### PR TITLE
Fix keypad scroll and add language selection

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -3,9 +3,11 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-hot-toast';
+import { Globe } from 'lucide-react';
 import { useBridge } from '@/app/context/bridgeContext';
 import { getAttendantUser } from '@/lib/attendant-auth';
 import { connBleByMacAddress, initServiceBleData } from '@/app/utils';
+import { useI18n } from '@/i18n';
 
 // Import components
 import {
@@ -52,12 +54,26 @@ interface AttendantFlowProps {
 export default function AttendantFlow({ onBack }: AttendantFlowProps) {
   const router = useRouter();
   const { bridge, isMqttConnected, isBridgeReady } = useBridge();
+  const { locale, setLocale, t } = useI18n();
   
   // Attendant info from login
   const [attendantInfo, setAttendantInfo] = useState<{ id: string; station: string }>({
     id: 'attendant-001',
     station: 'STATION_001',
   });
+
+  // Lock body overflow for fixed container
+  useEffect(() => {
+    document.body.classList.add('overflow-locked');
+    return () => {
+      document.body.classList.remove('overflow-locked');
+    };
+  }, []);
+
+  // Toggle locale function
+  const toggleLocale = useCallback(() => {
+    setLocale(locale === 'en' ? 'fr' : 'en');
+  }, [locale, setLocale]);
 
   // Load attendant info on mount
   useEffect(() => {
@@ -2722,15 +2738,25 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
     <div className="attendant-container">
       <div className="attendant-bg-gradient" />
       
-      {/* Back to Roles */}
-      <div style={{ padding: '8px 16px 0' }}>
-        <button className="back-to-roles" onClick={handleBackToRoles}>
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M19 12H5M12 19l-7-7 7-7"/>
-          </svg>
-          Change Role
-        </button>
-      </div>
+      {/* Header with Back and Language Toggle */}
+      <header className="flow-header">
+        <div className="flow-header-inner">
+          <button className="flow-header-back" onClick={handleBackToRoles}>
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M19 12H5M12 19l-7-7 7-7"/>
+            </svg>
+            <span>{t('attendant.changeRole')}</span>
+          </button>
+          <button
+            className="flow-header-lang"
+            onClick={toggleLocale}
+            aria-label={t('role.switchLanguage')}
+          >
+            <Globe size={16} />
+            <span className="flow-header-lang-label">{locale.toUpperCase()}</span>
+          </button>
+        </div>
+      </header>
 
       {/* Interactive Timeline */}
       <Timeline 

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -3,8 +3,10 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-hot-toast';
+import { Globe } from 'lucide-react';
 import { useBridge } from '@/app/context/bridgeContext';
 import { connBleByMacAddress, initServiceBleData } from '@/app/utils';
+import { useI18n } from '@/i18n';
 
 // Import components
 import {
@@ -53,6 +55,20 @@ interface SalesFlowProps {
 export default function SalesFlow({ onBack }: SalesFlowProps) {
   const router = useRouter();
   const { bridge, isBridgeReady } = useBridge();
+  const { locale, setLocale, t } = useI18n();
+  
+  // Lock body overflow for fixed container
+  useEffect(() => {
+    document.body.classList.add('overflow-locked');
+    return () => {
+      document.body.classList.remove('overflow-locked');
+    };
+  }, []);
+
+  // Toggle locale function
+  const toggleLocale = useCallback(() => {
+    setLocale(locale === 'en' ? 'fr' : 'en');
+  }, [locale, setLocale]);
   
   // Step management
   const [currentStep, setCurrentStep] = useState<SalesStep>(1);
@@ -904,15 +920,25 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
     <div className="sales-flow-container">
       <div className="sales-bg-gradient" />
       
-      {/* Back to Roles */}
-      <div style={{ padding: '8px 16px 0' }}>
-        <button className="back-to-roles" onClick={handleBackToRoles}>
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M19 12H5M12 19l-7-7 7-7"/>
-          </svg>
-          Change Role
-        </button>
-      </div>
+      {/* Header with Back and Language Toggle */}
+      <header className="flow-header">
+        <div className="flow-header-inner">
+          <button className="flow-header-back" onClick={handleBackToRoles}>
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M19 12H5M12 19l-7-7 7-7"/>
+            </svg>
+            <span>{t('sales.changeRole')}</span>
+          </button>
+          <button
+            className="flow-header-lang"
+            onClick={toggleLocale}
+            aria-label={t('role.switchLanguage')}
+          >
+            <Globe size={16} />
+            <span className="flow-header-lang-label">{locale.toUpperCase()}</span>
+          </button>
+        </div>
+      </header>
 
       {/* Timeline */}
       <SalesTimeline 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,6 +114,11 @@
 
 html, body {
   height: 100%;
+}
+
+/* Apply overflow:hidden only to pages that use fixed containers (new design) */
+/* Legacy pages like Keypad need to scroll normally */
+body.overflow-locked {
   overflow: hidden;
 }
 
@@ -4086,5 +4091,117 @@ html.theme-transition *::after {
   
   .checkout-total-value {
     font-size: 16px;
+  }
+}
+
+/* ===================== */
+/* FLOW HEADER COMPONENT */
+/* ===================== */
+
+.flow-header {
+  position: relative;
+  z-index: 20;
+  padding: 12px 16px;
+  flex-shrink: 0;
+}
+
+.flow-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  max-width: 430px;
+  margin: 0 auto;
+}
+
+.flow-header-back {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: 'Outfit', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.flow-header-back:hover {
+  background: var(--bg-tertiary);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.flow-header-back svg {
+  width: 14px;
+  height: 14px;
+}
+
+.flow-header-spacer {
+  width: 70px;
+}
+
+.flow-header-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  flex: 1;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.flow-header-lang {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: 'Outfit', sans-serif;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.flow-header-lang:hover {
+  background: var(--bg-tertiary);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.flow-header-lang svg {
+  width: 14px;
+  height: 14px;
+}
+
+.flow-header-lang-label {
+  min-width: 18px;
+  text-align: center;
+}
+
+@media (max-height: 700px) {
+  .flow-header {
+    padding: 8px 12px;
+  }
+  
+  .flow-header-back,
+  .flow-header-lang {
+    padding: 5px 8px;
+    font-size: 11px;
+  }
+  
+  .flow-header-title {
+    font-size: 13px;
   }
 }

--- a/src/components/FlowHeader.tsx
+++ b/src/components/FlowHeader.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft, Globe } from 'lucide-react';
+import { useI18n } from '@/i18n';
+
+interface FlowHeaderProps {
+  showBack?: boolean;
+  backPath?: string;
+  onBack?: () => void;
+  title?: string;
+}
+
+/**
+ * Shared header component for new design flow pages.
+ * Includes language switcher and optional back navigation.
+ * Also manages body overflow for fixed containers.
+ */
+export default function FlowHeader({ showBack = true, backPath, onBack, title }: FlowHeaderProps) {
+  const { locale, setLocale, t } = useI18n();
+  const router = useRouter();
+
+  // Lock body overflow when this component mounts (for fixed container pages)
+  useEffect(() => {
+    document.body.classList.add('overflow-locked');
+    return () => {
+      document.body.classList.remove('overflow-locked');
+    };
+  }, []);
+
+  const handleBack = () => {
+    if (onBack) {
+      onBack();
+    } else if (backPath) {
+      router.push(backPath);
+    } else {
+      router.back();
+    }
+  };
+
+  const toggleLocale = () => {
+    setLocale(locale === 'en' ? 'fr' : 'en');
+  };
+
+  return (
+    <header className="flow-header">
+      <div className="flow-header-inner">
+        {showBack ? (
+          <button
+            className="flow-header-back"
+            onClick={handleBack}
+            aria-label={t('Back')}
+          >
+            <ArrowLeft size={18} />
+            <span>{t('Back')}</span>
+          </button>
+        ) : (
+          <div className="flow-header-spacer" />
+        )}
+        
+        {title && <h1 className="flow-header-title">{title}</h1>}
+        
+        <button
+          className="flow-header-lang"
+          onClick={toggleLocale}
+          aria-label={t('Switch language')}
+        >
+          <Globe size={16} />
+          <span className="flow-header-lang-label">{locale.toUpperCase()}</span>
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/src/components/roles/SelectRole.tsx
+++ b/src/components/roles/SelectRole.tsx
@@ -1,58 +1,89 @@
 'use client';
 
+import { useEffect } from 'react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { Globe } from 'lucide-react';
+import { useI18n } from '@/i18n';
 
 interface RoleConfig {
   id: string;
-  label: string;
+  labelKey: string;
   image: string;
   path: string;
   disabled?: boolean;
-  badge?: string;
+  badgeKey?: string;
 }
 
 const roles: RoleConfig[] = [
   {
     id: 'attendant',
-    label: 'Attendant',
+    labelKey: 'role.attendant',
     image: '/assets/Attendant.png',
     path: '/attendant/attendant',
   },
   {
     id: 'sales',
-    label: 'Sales Rep',
+    labelKey: 'role.salesRep',
     image: '/assets/Sales.png',
     path: '/customers/customerform',
   },
   {
     id: 'keypad',
-    label: 'Keypad',
+    labelKey: 'role.keypad',
     image: '/assets/Keypad.png',
     path: '/keypad/keypad',
   },
   {
     id: 'rider',
-    label: 'Rider',
+    labelKey: 'role.rider',
     image: '/assets/Rider.png',
     path: '/rider/serviceplan1',
     disabled: true,
-    badge: 'Coming Soon',
+    badgeKey: 'role.comingSoon',
   },
 ];
 
 export default function SelectRole() {
   const router = useRouter();
+  const { locale, setLocale, t } = useI18n();
+
+  // Lock body overflow for fixed container
+  useEffect(() => {
+    document.body.classList.add('overflow-locked');
+    return () => {
+      document.body.classList.remove('overflow-locked');
+    };
+  }, []);
 
   const handleRoleClick = (role: RoleConfig) => {
     if (role.disabled) return;
     router.push(role.path);
   };
 
+  const toggleLocale = () => {
+    setLocale(locale === 'en' ? 'fr' : 'en');
+  };
+
   return (
     <div className="select-role-container">
       {/* Background gradient */}
       <div className="select-role-bg-gradient" />
+
+      {/* Language Switcher Header */}
+      <header className="flow-header">
+        <div className="flow-header-inner">
+          <div className="flow-header-spacer" />
+          <button
+            className="flow-header-lang"
+            onClick={toggleLocale}
+            aria-label={t('role.switchLanguage')}
+          >
+            <Globe size={16} />
+            <span className="flow-header-lang-label">{locale.toUpperCase()}</span>
+          </button>
+        </div>
+      </header>
 
       <main className="select-role-main">
         <div className="role-selection">
@@ -75,9 +106,9 @@ export default function SelectRole() {
 
           {/* Title Section */}
           <div className="role-header">
-            <h1 className="role-title">Select Your Role</h1>
+            <h1 className="role-title">{t('role.selectTitle')}</h1>
             <p className="role-description">
-              Choose <strong>your role</strong> to access the right tools for your daily tasks.
+              {t('role.selectDescription')}
             </p>
           </div>
 
@@ -92,15 +123,15 @@ export default function SelectRole() {
                 <div className="role-applet-image">
                   <Image
                     src={role.image}
-                    alt={role.label}
+                    alt={t(role.labelKey)}
                     width={100}
                     height={100}
                   />
                 </div>
-                <span className="role-applet-label">{role.label}</span>
+                <span className="role-applet-label">{t(role.labelKey)}</span>
                 
-                {role.badge && (
-                  <span className="role-applet-badge">{role.badge}</span>
+                {role.badgeKey && (
+                  <span className="role-applet-badge">{t(role.badgeKey)}</span>
                 )}
               </div>
             ))}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -939,5 +939,19 @@
   "Kenya": "Kenya",
   "Philippines": "Philippines",
   "Togo": "Togo",
-  "Shenzhen": "Shenzhen"
+  "Shenzhen": "Shenzhen",
+  
+  "role.selectTitle": "Select Your Role",
+  "role.selectDescription": "Choose your role to access the right tools for your daily tasks.",
+  "role.attendant": "Attendant",
+  "role.salesRep": "Sales Rep",
+  "role.keypad": "Keypad",
+  "role.rider": "Rider",
+  "role.comingSoon": "Coming Soon",
+  "role.switchLanguage": "Switch language",
+  
+  "attendant.changeRole": "Change Role",
+  "sales.changeRole": "Change Role",
+  
+  "Back": "Back"
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -930,7 +930,19 @@
   "Kenya": "Kenya",
   "Philippines": "Philippines",
   "Togo": "Togo",
-  "Shenzhen": "Shenzhen"
+  "Shenzhen": "Shenzhen",
+  
+  "role.selectTitle": "Sélectionnez votre rôle",
+  "role.selectDescription": "Choisissez votre rôle pour accéder aux outils adaptés à vos tâches quotidiennes.",
+  "role.attendant": "Préposé",
+  "role.salesRep": "Commercial",
+  "role.keypad": "Clavier",
+  "role.rider": "Conducteur",
+  "role.comingSoon": "Bientôt",
+  "role.switchLanguage": "Changer de langue",
+  
+  "attendant.changeRole": "Changer de rôle",
+  "sales.changeRole": "Changer de rôle",
+  
+  "Back": "Retour"
 }
-
-


### PR DESCRIPTION
Fixes scrolling on legacy pages like Keypad and adds language selection to new design pages (Roles, Attendant, Sales).

The new design for roles, attendant, and sales pages introduced `overflow: hidden` globally, preventing scrolling on older pages like Keypad. This PR refactors the overflow handling to be specific to new design pages and introduces a shared header with language selection, which is critical for internationalization.

---
<a href="https://cursor.com/background-agent?bcId=bc-7588bb18-71c5-4afe-b1e8-341d0444edbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7588bb18-71c5-4afe-b1e8-341d0444edbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

