### PR TITLE
Fix uniform section heights on select plans page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3844,6 +3844,8 @@ html.theme-transition *::after {
   display: flex;
   align-items: center;
   gap: 10px;
+  min-height: 64px;
+  height: 64px;
 }
 
 .product-card:hover {
@@ -3890,17 +3892,29 @@ html.theme-transition *::after {
 
 .product-info {
   flex: 1;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .product-name {
   font-size: 12px;
   font-weight: 500;
   margin-bottom: 1px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .product-desc {
   font-size: 10px;
   color: var(--text-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.4;
+  max-height: 2.8em;
 }
 
 .product-price {
@@ -4185,6 +4199,8 @@ html.theme-transition *::after {
   
   .product-card {
     padding: 8px 10px;
+    min-height: 56px;
+    height: 56px;
   }
   
   .preview-card {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3844,8 +3844,8 @@ html.theme-transition *::after {
   display: flex;
   align-items: center;
   gap: 10px;
-  min-height: 64px;
-  height: 64px;
+  min-height: 68px;
+  height: 68px;
 }
 
 .product-card:hover {
@@ -3899,22 +3899,21 @@ html.theme-transition *::after {
 .product-name {
   font-size: 12px;
   font-weight: 500;
-  margin-bottom: 1px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.product-desc {
-  font-size: 10px;
-  color: var(--text-muted);
+  margin-bottom: 2px;
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 1.4;
-  max-height: 2.8em;
+  line-height: 1.3;
+}
+
+.product-desc {
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .product-price {
@@ -4199,8 +4198,8 @@ html.theme-transition *::after {
   
   .product-card {
     padding: 8px 10px;
-    min-height: 56px;
-    height: 56px;
+    min-height: 60px;
+    height: 60px;
   }
   
   .preview-card {


### PR DESCRIPTION
Fix product card heights and truncate overflowing text on the Salesman Workflow's Select Plans page to ensure uniform UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3338d96-ee4e-48db-9c5d-490a0b892227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3338d96-ee4e-48db-9c5d-490a0b892227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

