### PR TITLE
Add ble device manager and rider roles

### DIFF
--- a/src/components/roles/SelectRole.tsx
+++ b/src/components/roles/SelectRole.tsx
@@ -29,18 +29,22 @@ const roles: RoleConfig[] = [
     path: '/customers/customerform',
   },
   {
+    id: 'rider',
+    labelKey: 'role.rider',
+    image: '/assets/Rider.png',
+    path: '/rider/serviceplan1',
+  },
+  {
     id: 'keypad',
     labelKey: 'role.keypad',
     image: '/assets/Keypad.png',
     path: '/keypad/keypad',
   },
   {
-    id: 'rider',
-    labelKey: 'role.rider',
-    image: '/assets/Rider.png',
-    path: '/rider/serviceplan1',
-    disabled: true,
-    badgeKey: 'role.comingSoon',
+    id: 'bleDeviceManager',
+    labelKey: 'role.bleDeviceManager',
+    image: '/assets/Ble-Device-Attendant.png',
+    path: '/assets/ble-devices',
   },
 ];
 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -947,6 +947,7 @@
   "role.salesRep": "Sales Rep",
   "role.keypad": "Keypad",
   "role.rider": "Rider",
+  "role.bleDeviceManager": "BLE Device Manager",
   "role.comingSoon": "Coming Soon",
   "role.switchLanguage": "Switch language",
   

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -938,6 +938,7 @@
   "role.salesRep": "Commercial",
   "role.keypad": "Clavier",
   "role.rider": "Conducteur",
+  "role.bleDeviceManager": "Gestionnaire BLE",
   "role.comingSoon": "Bientôt",
   "role.switchLanguage": "Changer de langue",
   


### PR DESCRIPTION
Add 'BLE Device Manager' role to the Select Role page and enable the 'Rider' role to expand available user options.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9464ecb-b1a6-416e-b90a-eea08b46da31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c9464ecb-b1a6-416e-b90a-eea08b46da31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

