### PR TITLE
Investigate missing Chinese language option

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -76,7 +76,8 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
 
   // Toggle locale function
   const toggleLocale = useCallback(() => {
-    setLocale(locale === 'en' ? 'fr' : 'en');
+    const nextLocale = locale === 'en' ? 'fr' : locale === 'fr' ? 'zh' : 'en';
+    setLocale(nextLocale);
   }, [locale, setLocale]);
 
   // Load attendant info on mount

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -73,7 +73,8 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
 
   // Toggle locale function
   const toggleLocale = useCallback(() => {
-    setLocale(locale === 'en' ? 'fr' : 'en');
+    const nextLocale = locale === 'en' ? 'fr' : locale === 'fr' ? 'zh' : 'en';
+    setLocale(nextLocale);
   }, [locale, setLocale]);
   
   // Step management

--- a/src/components/FlowHeader.tsx
+++ b/src/components/FlowHeader.tsx
@@ -40,7 +40,8 @@ export default function FlowHeader({ showBack = true, backPath, onBack, title }:
   };
 
   const toggleLocale = () => {
-    setLocale(locale === 'en' ? 'fr' : 'en');
+    const nextLocale = locale === 'en' ? 'fr' : locale === 'fr' ? 'zh' : 'en';
+    setLocale(nextLocale);
   };
 
   return (

--- a/src/components/roles/SelectRole.tsx
+++ b/src/components/roles/SelectRole.tsx
@@ -66,7 +66,8 @@ export default function SelectRole() {
   };
 
   const toggleLocale = () => {
-    setLocale(locale === 'en' ? 'fr' : 'en');
+    const nextLocale = locale === 'en' ? 'fr' : locale === 'fr' ? 'zh' : 'en';
+    setLocale(nextLocale);
   };
 
   return (


### PR DESCRIPTION
Update language toggle logic to include Chinese.

The language toggle button in `FlowHeader.tsx`, `SelectRole.tsx`, `SalesFlow.tsx`, and `AttendantFlow.tsx` only cycled between English and French, despite Chinese being fully internationalized. This PR updates the `toggleLocale` function in these components to cycle through English, French, and Chinese.

---
<a href="https://cursor.com/background-agent?bcId=bc-41585479-f6cd-4fda-9f81-e5135386c6bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-41585479-f6cd-4fda-9f81-e5135386c6bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

