### PR TITLE
Move confirm payment button to scan section

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/steps/Step5Payment.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step5Payment.tsx
@@ -103,25 +103,32 @@ export default function Step5Payment({ swapData, customerData, onConfirmPayment,
                   autoComplete="off"
                 />
               </div>
-              <button 
-                className="btn btn-primary" 
-                style={{ width: '100%', marginTop: '8px' }}
-                onClick={handleManualConfirm}
-                disabled={isProcessing || !paymentId.trim()}
-              >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M20 6L9 17l-5-5"/>
-                </svg>
-                {isProcessing ? t('attendant.confirmingPayment') : t('sales.confirmPayment')}
-              </button>
             </div>
             
-            <p className="scan-hint" style={{ marginTop: '8px' }}>
+            {/* Large Confirm Payment button - matches ScannerArea placement and prominence */}
+            <button 
+              className="confirm-payment-cta" 
+              onClick={handleManualConfirm}
+              disabled={isProcessing || !paymentId.trim()}
+            >
+              <div className="confirm-payment-cta-inner">
+                <div className="confirm-payment-cta-icon">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M20 6L9 17l-5-5"/>
+                  </svg>
+                </div>
+                <span className="confirm-payment-cta-text">
+                  {isProcessing ? t('attendant.confirmingPayment') : t('sales.confirmPayment')}
+                </span>
+              </div>
+            </button>
+            
+            <p className="scan-hint">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="10"/>
                 <path d="M12 16v-4M12 8h.01"/>
               </svg>
-              {t('attendant.enterMpesaCode')}
+              {t('sales.tapToConfirmPayment')}
             </p>
           </div>
         )}

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -125,6 +125,7 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
   const [paymentConfirmed, setPaymentConfirmed] = useState(false);
   const [paymentReference, setPaymentReference] = useState<string>('');
   const [paymentInitiated, setPaymentInitiated] = useState(false);
+  const [paymentInputMode, setPaymentInputMode] = useState<'scan' | 'manual'>('scan');
   
   // Payment amount tracking for incomplete payments
   const [paymentAmountPaid, setPaymentAmountPaid] = useState<number>(0);
@@ -1171,6 +1172,11 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
   const handlePlanSelect = useCallback((planId: string) => {
     setSelectedPlanId(planId);
   }, []);
+  
+  // Handle payment input mode change
+  const handlePaymentInputModeChange = useCallback((mode: 'scan' | 'manual') => {
+    setPaymentInputMode(mode);
+  }, []);
 
   // Handle battery scan
   const handleScanBattery = useCallback(() => {
@@ -1325,6 +1331,7 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
             amountPaid={paymentAmountPaid}
             amountExpected={paymentAmountExpected}
             amountRemaining={paymentAmountRemaining}
+            onInputModeChange={handlePaymentInputModeChange}
           />
         );
       case 4:
@@ -1441,12 +1448,14 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
         {renderStepContent()}
       </main>
 
-      {/* Action Bar */}
+      {/* Action Bar - disabled in manual payment mode since user should use the CTA in content area */}
       <SalesActionBar
         currentStep={currentStep}
         onBack={handleBack}
         onMainAction={handleMainAction}
         isLoading={isProcessing || isCreatingCustomer}
+        paymentInputMode={paymentInputMode}
+        isDisabled={currentStep === 3 && paymentInputMode === 'manual'}
       />
 
       {/* Loading Overlay - Simple overlay for non-BLE operations (customer registration, processing) */}

--- a/src/app/(mobile)/customers/customerform/components/SalesActionBar.tsx
+++ b/src/app/(mobile)/customers/customerform/components/SalesActionBar.tsx
@@ -10,6 +10,7 @@ interface SalesActionBarProps {
   onMainAction: () => void;
   isLoading: boolean;
   isDisabled?: boolean;
+  paymentInputMode?: 'scan' | 'manual'; // For step 3 to show correct button text
 }
 
 // Icon components for action bar
@@ -17,6 +18,11 @@ const ActionIcons = {
   arrow: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M5 12h14M12 5l7 7-7 7"/>
+    </svg>
+  ),
+  check: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 6L9 17l-5-5"/>
     </svg>
   ),
   scan: (
@@ -43,13 +49,17 @@ interface StepActionConfig {
   mainClass?: string;
 }
 
-const getStepConfig = (step: SalesStep): StepActionConfig => {
+const getStepConfig = (step: SalesStep, paymentInputMode?: 'scan' | 'manual'): StepActionConfig => {
   switch (step) {
     case 1:
       return { showBack: false, mainTextKey: 'sales.continue', mainIcon: 'arrow' };
     case 2:
       return { showBack: true, mainTextKey: 'sales.continue', mainIcon: 'arrow' };
     case 3:
+      // Show "Confirm Payment" when in manual mode, "Scan Payment QR" when in scan mode
+      if (paymentInputMode === 'manual') {
+        return { showBack: true, mainTextKey: 'sales.confirmPayment', mainIcon: 'check' };
+      }
       return { showBack: true, mainTextKey: 'sales.scanPaymentQr', mainIcon: 'scan' };
     case 4:
       return { showBack: true, mainTextKey: 'sales.scanBattery', mainIcon: 'scan' };
@@ -60,9 +70,9 @@ const getStepConfig = (step: SalesStep): StepActionConfig => {
   }
 };
 
-export default function SalesActionBar({ currentStep, onBack, onMainAction, isLoading, isDisabled }: SalesActionBarProps) {
+export default function SalesActionBar({ currentStep, onBack, onMainAction, isLoading, isDisabled, paymentInputMode }: SalesActionBarProps) {
   const { t } = useI18n();
-  const config = getStepConfig(currentStep);
+  const config = getStepConfig(currentStep, paymentInputMode);
 
   return (
     <div className="action-bar">

--- a/src/app/(mobile)/customers/customerform/components/steps/Step3Payment.tsx
+++ b/src/app/(mobile)/customers/customerform/components/steps/Step3Payment.tsx
@@ -23,6 +23,8 @@ interface Step3Props {
   amountPaid?: number;
   amountExpected?: number;
   amountRemaining?: number;
+  // Input mode callback to inform parent (for action bar)
+  onInputModeChange?: (mode: 'scan' | 'manual') => void;
 }
 
 export default function Step3Payment({ 
@@ -37,10 +39,17 @@ export default function Step3Payment({
   amountPaid = 0,
   amountExpected = 0,
   amountRemaining = 0,
+  onInputModeChange,
 }: Step3Props) {
   const { t } = useI18n();
   const [inputMode, setInputMode] = useState<'scan' | 'manual'>('scan');
   const [paymentId, setPaymentId] = useState('');
+  
+  // Notify parent when input mode changes
+  const handleInputModeChange = (mode: 'scan' | 'manual') => {
+    setInputMode(mode);
+    onInputModeChange?.(mode);
+  };
 
   const selectedPlan = plans.find(p => p.id === selectedPlanId);
   const customerName = `${formData.firstName} ${formData.lastName}`;
@@ -130,7 +139,7 @@ export default function Step3Payment({
         <div className="input-toggle">
           <button 
             className={`toggle-btn ${inputMode === 'scan' ? 'active' : ''}`}
-            onClick={() => setInputMode('scan')}
+            onClick={() => handleInputModeChange('scan')}
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <rect x="3" y="3" width="7" height="7"/>
@@ -142,7 +151,7 @@ export default function Step3Payment({
           </button>
           <button 
             className={`toggle-btn ${inputMode === 'manual' ? 'active' : ''}`}
-            onClick={() => setInputMode('manual')}
+            onClick={() => handleInputModeChange('manual')}
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M12 20h9"/>
@@ -181,25 +190,32 @@ export default function Step3Payment({
                   autoComplete="off"
                 />
               </div>
-              <button 
-                className="btn btn-primary" 
-                style={{ width: '100%', marginTop: '8px' }}
-                onClick={handleManualConfirm}
-                disabled={isProcessing || !paymentId.trim()}
-              >
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M20 6L9 17l-5-5"/>
-                </svg>
-                {isProcessing ? t('sales.processing') : t('sales.confirmPayment')}
-              </button>
             </div>
             
-            <p className="scan-hint" style={{ marginTop: '8px' }}>
+            {/* Large Confirm Payment button - matches ScannerArea placement and prominence */}
+            <button 
+              className="confirm-payment-cta" 
+              onClick={handleManualConfirm}
+              disabled={isProcessing || !paymentId.trim()}
+            >
+              <div className="confirm-payment-cta-inner">
+                <div className="confirm-payment-cta-icon">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M20 6L9 17l-5-5"/>
+                  </svg>
+                </div>
+                <span className="confirm-payment-cta-text">
+                  {isProcessing ? t('sales.processing') : t('sales.confirmPayment')}
+                </span>
+              </div>
+            </button>
+            
+            <p className="scan-hint">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="10"/>
                 <path d="M12 16v-4M12 8h.01"/>
               </svg>
-              {t('sales.orEnterManually')}
+              {t('sales.tapToConfirmPayment')}
             </p>
           </div>
         )}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1932,7 +1932,75 @@ html.theme-transition *::after {
 }
 
 .payment-input-mode-manual .manual-entry-form {
-  margin-bottom: 0;
+  margin-bottom: 16px;
+}
+
+/* Large Confirm Payment CTA - matches ScannerArea size and prominence */
+.confirm-payment-cta {
+  width: 140px;
+  height: 140px;
+  margin: 16px auto;
+  padding: 0;
+  border: 2px solid var(--accent);
+  border-radius: var(--radius-xl);
+  background: var(--bg-secondary);
+  cursor: pointer;
+  transition: all 0.3s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirm-payment-cta:hover:not(:disabled) {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-glow);
+  background: rgba(var(--accent-rgb), 0.1);
+}
+
+.confirm-payment-cta:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  border-color: var(--border);
+}
+
+.confirm-payment-cta-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.confirm-payment-cta-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.confirm-payment-cta-icon svg {
+  width: 24px;
+  height: 24px;
+  stroke: white;
+}
+
+.confirm-payment-cta-text {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+  text-align: center;
+  line-height: 1.2;
+}
+
+.confirm-payment-cta:disabled .confirm-payment-cta-icon {
+  background: var(--text-muted);
+}
+
+.confirm-payment-cta:disabled .confirm-payment-cta-text {
+  color: var(--text-muted);
 }
 
 /* Payment Scan */

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1015,6 +1015,7 @@
   "sales.transactionId": "Transaction ID",
   "sales.enterTransactionId": "Enter transaction ID",
   "sales.confirmPayment": "Confirm Payment",
+  "sales.tapToConfirmPayment": "Tap above to confirm your transaction",
   
   "sales.assignBattery": "Assign Battery",
   "sales.scanBatteryQr": "Scan the battery QR code to assign to customer",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1006,6 +1006,7 @@
   "sales.transactionId": "ID de transaction",
   "sales.enterTransactionId": "Entrer l'ID de transaction",
   "sales.confirmPayment": "Confirmer le paiement",
+  "sales.tapToConfirmPayment": "Appuyez ci-dessus pour confirmer votre transaction",
   
   "sales.assignBattery": "Attribuer la batterie",
   "sales.scanBatteryQr": "Scanner le code QR de la batterie à attribuer au client",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -917,6 +917,7 @@
   "sales.transactionId": "交易ID",
   "sales.enterTransactionId": "输入交易ID",
   "sales.confirmPayment": "确认支付",
+  "sales.tapToConfirmPayment": "点击上方确认您的交易",
   
   "sales.assignBattery": "分配电池",
   "sales.scanBatteryQr": "扫描电池二维码以分配给客户",


### PR DESCRIPTION
Refactor the "Confirm Payment" page in the SalesPerson Workflow to improve UX for manual payment entry.

The previous layout had a small "Confirm Payment" button next to the input field and a "Scan Payment QR" button in the bottom action bar, even when manually entering a transaction ID. This was confusing and inconsistent. This PR removes the inline button, introduces a large, prominent "Confirm Payment" CTA in the main content area for manual mode, and makes the bottom action bar context-aware to reflect the current payment input mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-444cb653-b026-4a69-ab64-66e03b660d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-444cb653-b026-4a69-ab64-66e03b660d63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

