### PR TITLE
Investigate missing omnivoltaic logo on pages

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-hot-toast';
 import { Globe } from 'lucide-react';
+import Image from 'next/image';
 import { useBridge } from '@/app/context/bridgeContext';
 import { getAttendantUser } from '@/lib/attendant-auth';
 import { connBleByMacAddress, initServiceBleData } from '@/app/utils';
@@ -2894,7 +2895,7 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
     <div className="attendant-container">
       <div className="attendant-bg-gradient" />
       
-      {/* Header with Back and Language Toggle */}
+      {/* Header with Back, Logo, and Language Toggle */}
       <header className="flow-header">
         <div className="flow-header-inner">
           <button className="flow-header-back" onClick={handleBackToRoles}>
@@ -2903,6 +2904,14 @@ export default function AttendantFlow({ onBack }: AttendantFlowProps) {
             </svg>
             <span>{t('attendant.changeRole')}</span>
           </button>
+          <Image
+            src="/assets/Logo-Oves.png"
+            alt="Omnivoltaic"
+            width={100}
+            height={32}
+            style={{ objectFit: 'contain' }}
+            priority
+          />
           <button
             className="flow-header-lang"
             onClick={toggleLocale}

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -4,6 +4,7 @@ import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'react-hot-toast';
 import { Globe } from 'lucide-react';
+import Image from 'next/image';
 import { useBridge } from '@/app/context/bridgeContext';
 import { connBleByMacAddress, initServiceBleData } from '@/app/utils';
 import { useI18n } from '@/i18n';
@@ -1416,7 +1417,7 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
     <div className="sales-flow-container">
       <div className="sales-bg-gradient" />
       
-      {/* Header with Back and Language Toggle */}
+      {/* Header with Back, Logo, and Language Toggle */}
       <header className="flow-header">
         <div className="flow-header-inner">
           <button className="flow-header-back" onClick={handleBackToRoles}>
@@ -1425,6 +1426,14 @@ export default function SalesFlow({ onBack }: SalesFlowProps) {
             </svg>
             <span>{t('sales.changeRole')}</span>
           </button>
+          <Image
+            src="/assets/Logo-Oves.png"
+            alt="Omnivoltaic"
+            width={100}
+            height={32}
+            style={{ objectFit: 'contain' }}
+            priority
+          />
           <button
             className="flow-header-lang"
             onClick={toggleLocale}

--- a/src/components/roles/SelectRole.tsx
+++ b/src/components/roles/SelectRole.tsx
@@ -75,10 +75,18 @@ export default function SelectRole() {
       {/* Background gradient */}
       <div className="select-role-bg-gradient" />
 
-      {/* Language Switcher Header */}
+      {/* Header with Logo and Language Switcher */}
       <header className="flow-header">
         <div className="flow-header-inner">
           <div className="flow-header-spacer" />
+          <Image
+            src="/assets/Logo-Oves.png"
+            alt="Omnivoltaic"
+            width={100}
+            height={32}
+            style={{ objectFit: 'contain' }}
+            priority
+          />
           <button
             className="flow-header-lang"
             onClick={toggleLocale}


### PR DESCRIPTION
Add Omnivoltaic logo to the headers of the Roles, Attendant, and Sales Person pages.

The logo was not appearing on these pages because their fixed-position headers were covering the main layout's logo, causing it to be invisible. This PR explicitly adds the logo to these specific headers for consistent branding.

---
<a href="https://cursor.com/background-agent?bcId=bc-b4885f32-ae08-4a93-9733-b1fbd4d03fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b4885f32-ae08-4a93-9733-b1fbd4d03fe0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

