### PR TITLE
Restore attendant workflow button layout

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -196,6 +196,11 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
   // Transaction ID
   const [transactionId, setTransactionId] = useState<string>('');
   
+  // Payment step input mode (scan QR or manual entry)
+  const [paymentInputMode, setPaymentInputMode] = useState<'scan' | 'manual'>('scan');
+  // Manual payment ID input
+  const [manualPaymentId, setManualPaymentId] = useState<string>('');
+  
   // Ref for correlation ID
   const correlationIdRef = useRef<string>('');
   
@@ -3022,13 +3027,23 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
         handleProceedToPayment();
         break;
       case 5:
-        handleConfirmPayment();
+        // Handle payment based on input mode
+        if (paymentInputMode === 'scan') {
+          handleConfirmPayment();
+        } else {
+          // Manual mode - call backend with manual payment ID
+          if (manualPaymentId.trim()) {
+            handleManualPayment(manualPaymentId.trim());
+          } else {
+            toast.error(t('sales.enterTransactionId'));
+          }
+        }
         break;
       case 6:
         handleNewSwap();
         break;
     }
-  }, [currentStep, inputMode, handleScanCustomer, handleManualLookup, handleScanOldBattery, handleScanNewBattery, handleProceedToPayment, handleConfirmPayment, handleNewSwap]);
+  }, [currentStep, inputMode, paymentInputMode, manualPaymentId, handleScanCustomer, handleManualLookup, handleScanOldBattery, handleScanNewBattery, handleProceedToPayment, handleConfirmPayment, handleManualPayment, handleNewSwap, t]);
 
   // Render current step content
   const renderStepContent = () => {
@@ -3080,10 +3095,11 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
           <Step5Payment 
             swapData={swapData}
             customerData={customerData}
-            onConfirmPayment={handleConfirmPayment}
-            onManualPayment={handleManualPayment}
             isProcessing={isProcessing || paymentAndServiceStatus === 'pending'}
-            isScannerOpening={isScanning}
+            inputMode={paymentInputMode}
+            setInputMode={setPaymentInputMode}
+            paymentId={manualPaymentId}
+            setPaymentId={setManualPaymentId}
           />
         );
       case 6:
@@ -3175,6 +3191,7 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
         onMainAction={handleMainAction}
         isLoading={isScanning || isProcessing || paymentAndServiceStatus === 'pending'}
         inputMode={inputMode}
+        paymentInputMode={paymentInputMode}
         hasSufficientQuota={hasSufficientQuota}
       />
 

--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -3067,8 +3067,6 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
           <Step2OldBattery 
             onScanOldBattery={handleScanOldBattery}
             isFirstTimeCustomer={customerType === 'first-time'}
-            isBleScanning={bleScanState.isScanning}
-            detectedDevicesCount={bleScanState.detectedDevices.length}
             isScannerOpening={isScanning}
           />
         );
@@ -3077,8 +3075,6 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
           <Step3NewBattery 
             oldBattery={swapData.oldBattery} 
             onScanNewBattery={handleScanNewBattery}
-            isBleScanning={bleScanState.isScanning}
-            detectedDevicesCount={bleScanState.detectedDevices.length}
             isScannerOpening={isScanning}
           />
         );

--- a/src/app/(mobile)/attendant/attendant/components/ActionBar.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/ActionBar.tsx
@@ -10,6 +10,7 @@ interface ActionBarProps {
   onMainAction: () => void;
   isLoading: boolean;
   inputMode?: 'scan' | 'manual';
+  paymentInputMode?: 'scan' | 'manual';
   hasSufficientQuota?: boolean;
 }
 
@@ -59,7 +60,7 @@ interface StepActionConfig {
   mainClass?: string;
 }
 
-const getStepConfig = (step: AttendantStep, inputMode?: 'scan' | 'manual', hasSufficientQuota?: boolean): StepActionConfig => {
+const getStepConfig = (step: AttendantStep, inputMode?: 'scan' | 'manual', hasSufficientQuota?: boolean, paymentInputMode?: 'scan' | 'manual'): StepActionConfig => {
   switch (step) {
     case 1:
       // Show different text/icon based on input mode
@@ -78,7 +79,12 @@ const getStepConfig = (step: AttendantStep, inputMode?: 'scan' | 'manual', hasSu
       }
       return { showBack: true, mainTextKey: 'attendant.collectPayment', mainIcon: 'arrow' };
     case 5:
-      return { showBack: true, mainTextKey: 'attendant.confirmPayment', mainIcon: 'qr' };
+      // Show appropriate icon based on payment input mode (scan QR or manual entry)
+      return { 
+        showBack: true, 
+        mainTextKey: 'attendant.confirmPayment', 
+        mainIcon: paymentInputMode === 'manual' ? 'check' : 'qr' 
+      };
     case 6:
       return { showBack: false, mainTextKey: 'attendant.startNewSwap', mainIcon: 'plus', mainClass: 'btn-success' };
     default:
@@ -86,13 +92,12 @@ const getStepConfig = (step: AttendantStep, inputMode?: 'scan' | 'manual', hasSu
   }
 };
 
-export default function ActionBar({ currentStep, onBack, onMainAction, isLoading, inputMode, hasSufficientQuota }: ActionBarProps) {
+export default function ActionBar({ currentStep, onBack, onMainAction, isLoading, inputMode, paymentInputMode, hasSufficientQuota }: ActionBarProps) {
   const { t } = useI18n();
-  const config = getStepConfig(currentStep, inputMode, hasSufficientQuota);
+  const config = getStepConfig(currentStep, inputMode, hasSufficientQuota, paymentInputMode);
 
   // Don't show the action bar button for step 1 in manual mode - button is in the form
-  // Don't show for step 5 either - Step5Payment has its own action buttons for both scan and manual modes
-  const hideMainButton = (currentStep === 1 && inputMode === 'manual') || currentStep === 5;
+  const hideMainButton = currentStep === 1 && inputMode === 'manual';
 
   return (
     <div className="action-bar">

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step2OldBattery.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step2OldBattery.tsx
@@ -3,21 +3,16 @@
 import React from 'react';
 import { useI18n } from '@/i18n';
 import ScannerArea from '../ScannerArea';
-import { Bluetooth, Radio } from 'lucide-react';
 
 interface Step2Props {
   onScanOldBattery: () => void;
   isFirstTimeCustomer?: boolean;
-  isBleScanning?: boolean;
-  detectedDevicesCount?: number;
   isScannerOpening?: boolean; // Prevents multiple scanner opens
 }
 
 export default function Step2OldBattery({ 
   onScanOldBattery, 
   isFirstTimeCustomer,
-  isBleScanning = false,
-  detectedDevicesCount = 0,
   isScannerOpening = false,
 }: Step2Props) {
   const { t } = useI18n();
@@ -33,27 +28,6 @@ export default function Step2OldBattery({
             ? t('attendant.firstTimeCustomer')
             : t('attendant.scanReturnBattery')}
         </p>
-        
-        {/* BLE Scanning Status - Shows nearby batteries being detected */}
-        <div className={`bluetooth-notice ${isBleScanning ? 'ble-scanning-active' : ''}`}>
-          <div className="bluetooth-notice-icon">
-            {isBleScanning ? (
-              <Radio size={20} className="ble-scanning-icon" />
-            ) : (
-              <Bluetooth size={20} />
-            )}
-          </div>
-          <div className="bluetooth-notice-content">
-            <span className="bluetooth-notice-title">
-              {isBleScanning ? t('sales.scanningForDevices') : 'Bluetooth'}
-            </span>
-            <span className="bluetooth-notice-text">
-              {isBleScanning 
-                ? `${detectedDevicesCount} ${t('sales.devicesFound')}`
-                : t('attendant.scanReturnBattery')}
-            </span>
-          </div>
-        </div>
         
         <ScannerArea onClick={onScanOldBattery} type="battery" size="small" disabled={isScannerOpening} />
         

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step3NewBattery.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step3NewBattery.tsx
@@ -4,21 +4,16 @@ import React from 'react';
 import { useI18n } from '@/i18n';
 import ScannerArea from '../ScannerArea';
 import { BatteryData, getBatteryClass } from '../types';
-import { Bluetooth, Radio } from 'lucide-react';
 
 interface Step3Props {
   oldBattery: BatteryData | null;
   onScanNewBattery: () => void;
-  isBleScanning?: boolean;
-  detectedDevicesCount?: number;
   isScannerOpening?: boolean; // Prevents multiple scanner opens
 }
 
 export default function Step3NewBattery({ 
   oldBattery, 
   onScanNewBattery,
-  isBleScanning = false,
-  detectedDevicesCount = 0,
   isScannerOpening = false,
 }: Step3Props) {
   const { t } = useI18n();
@@ -53,27 +48,6 @@ export default function Step3NewBattery({
       <div className="scan-prompt">
         <h1 className="scan-title">{t('attendant.issueNewBattery')}</h1>
         <p className="scan-subtitle">{t('attendant.scanNewBattery')}</p>
-        
-        {/* BLE Scanning Status - Shows nearby batteries being detected */}
-        <div className={`bluetooth-notice ${isBleScanning ? 'ble-scanning-active' : ''}`}>
-          <div className="bluetooth-notice-icon">
-            {isBleScanning ? (
-              <Radio size={20} className="ble-scanning-icon" />
-            ) : (
-              <Bluetooth size={20} />
-            )}
-          </div>
-          <div className="bluetooth-notice-content">
-            <span className="bluetooth-notice-title">
-              {isBleScanning ? t('sales.scanningForDevices') : 'Bluetooth'}
-            </span>
-            <span className="bluetooth-notice-text">
-              {isBleScanning 
-                ? `${detectedDevicesCount} ${t('sales.devicesFound')}`
-                : t('attendant.scanNewBattery')}
-            </span>
-          </div>
-        </div>
         
         <ScannerArea onClick={onScanNewBattery} type="battery" size="small" disabled={isScannerOpening} />
         

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step5Payment.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step5Payment.tsx
@@ -1,36 +1,29 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useI18n } from '@/i18n';
 import { SwapData, CustomerData, getInitials } from '../types';
-import ScannerArea from '../ScannerArea';
 
 interface Step5Props {
   swapData: SwapData;
   customerData?: CustomerData | null;
-  onConfirmPayment: () => void;
-  onManualPayment: (paymentId: string) => void;
   isProcessing: boolean;
-  isScannerOpening?: boolean; // Prevents multiple scanner opens
+  inputMode: 'scan' | 'manual';
+  setInputMode: (mode: 'scan' | 'manual') => void;
+  paymentId: string;
+  setPaymentId: (id: string) => void;
 }
 
-export default function Step5Payment({ swapData, customerData, onConfirmPayment, onManualPayment, isProcessing, isScannerOpening = false }: Step5Props) {
+export default function Step5Payment({ 
+  swapData, 
+  customerData, 
+  isProcessing, 
+  inputMode, 
+  setInputMode, 
+  paymentId, 
+  setPaymentId 
+}: Step5Props) {
   const { t } = useI18n();
-  const [inputMode, setInputMode] = useState<'scan' | 'manual'>('scan');
-  const [paymentId, setPaymentId] = useState('');
-
-  const handleManualConfirm = () => {
-    if (paymentId.trim()) {
-      onManualPayment(paymentId.trim());
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && paymentId.trim() && !isProcessing) {
-      e.preventDefault();
-      handleManualConfirm();
-    }
-  };
 
   return (
     <div className="screen active">
@@ -78,7 +71,18 @@ export default function Step5Payment({ swapData, customerData, onConfirmPayment,
           <div className="payment-input-mode">
             <p className="payment-subtitle">{t('attendant.enterMpesaCode')}</p>
             
-            <ScannerArea onClick={onConfirmPayment} type="qr" disabled={isScannerOpening} />
+            {/* Visual QR Scanner indicator - action triggered by Confirm Payment button in ActionBar */}
+            <div className="scanner-area qr-scanner-visual">
+              <div className="scanner-area-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="3" y="3" width="7" height="7"/>
+                  <rect x="14" y="3" width="7" height="7"/>
+                  <rect x="14" y="14" width="7" height="7"/>
+                  <rect x="3" y="14" width="7" height="7"/>
+                </svg>
+              </div>
+              <span className="scanner-area-text">{t('attendant.tapConfirmToScan')}</span>
+            </div>
             
             <p className="scan-hint">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -99,36 +103,18 @@ export default function Step5Payment({ swapData, customerData, onConfirmPayment,
                   placeholder={t('sales.enterTransactionId')}
                   value={paymentId}
                   onChange={(e) => setPaymentId(e.target.value)}
-                  onKeyDown={handleKeyDown}
                   autoComplete="off"
+                  disabled={isProcessing}
                 />
               </div>
             </div>
-            
-            {/* Large Confirm Payment button - matches ScannerArea placement and prominence */}
-            <button 
-              className="confirm-payment-cta" 
-              onClick={handleManualConfirm}
-              disabled={isProcessing || !paymentId.trim()}
-            >
-              <div className="confirm-payment-cta-inner">
-                <div className="confirm-payment-cta-icon">
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                    <path d="M20 6L9 17l-5-5"/>
-                  </svg>
-                </div>
-                <span className="confirm-payment-cta-text">
-                  {isProcessing ? t('attendant.confirmingPayment') : t('sales.confirmPayment')}
-                </span>
-              </div>
-            </button>
             
             <p className="scan-hint">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                 <circle cx="12" cy="12" r="10"/>
                 <path d="M12 16v-4M12 8h.01"/>
               </svg>
-              {t('sales.tapToConfirmPayment')}
+              {t('sales.tapConfirmToProcess')}
             </p>
           </div>
         )}

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1016,6 +1016,7 @@
   "sales.enterTransactionId": "Enter transaction ID",
   "sales.confirmPayment": "Confirm Payment",
   "sales.tapToConfirmPayment": "Tap above to confirm your transaction",
+  "sales.tapConfirmToProcess": "Tap Confirm Payment to process",
   
   "sales.assignBattery": "Assign Battery",
   "sales.scanBatteryQr": "Scan the battery QR code to assign to customer",
@@ -1100,6 +1101,8 @@
   "attendant.confirmingPayment": "Confirming payment...",
   "attendant.paymentConfirmed": "Payment Confirmed",
   "attendant.completeSwap": "Complete Swap",
+  "attendant.confirmPayment": "Confirm Payment",
+  "attendant.tapConfirmToScan": "Tap Confirm Payment to scan QR",
   
   "attendant.swapComplete": "Swap Complete!",
   "attendant.batteryIssued": "Battery has been issued successfully",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1007,6 +1007,7 @@
   "sales.enterTransactionId": "Entrer l'ID de transaction",
   "sales.confirmPayment": "Confirmer le paiement",
   "sales.tapToConfirmPayment": "Appuyez ci-dessus pour confirmer votre transaction",
+  "sales.tapConfirmToProcess": "Appuyez sur Confirmer pour traiter",
   
   "sales.assignBattery": "Attribuer la batterie",
   "sales.scanBatteryQr": "Scanner le code QR de la batterie à attribuer au client",
@@ -1091,6 +1092,8 @@
   "attendant.confirmingPayment": "Confirmation du paiement...",
   "attendant.paymentConfirmed": "Paiement confirmé",
   "attendant.completeSwap": "Terminer l'échange",
+  "attendant.confirmPayment": "Confirmer le paiement",
+  "attendant.tapConfirmToScan": "Appuyez sur Confirmer pour scanner le QR",
   
   "attendant.swapComplete": "Échange terminé !",
   "attendant.batteryIssued": "La batterie a été émise avec succès",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -918,6 +918,7 @@
   "sales.enterTransactionId": "输入交易ID",
   "sales.confirmPayment": "确认支付",
   "sales.tapToConfirmPayment": "点击上方确认您的交易",
+  "sales.tapConfirmToProcess": "点击确认支付以处理",
   
   "sales.assignBattery": "分配电池",
   "sales.scanBatteryQr": "扫描电池二维码以分配给客户",
@@ -1002,6 +1003,8 @@
   "attendant.confirmingPayment": "确认支付中...",
   "attendant.paymentConfirmed": "支付已确认",
   "attendant.completeSwap": "完成更换",
+  "attendant.confirmPayment": "确认支付",
+  "attendant.tapConfirmToScan": "点击确认支付扫描二维码",
   
   "attendant.swapComplete": "更换完成！",
   "attendant.batteryIssued": "电池已成功发放",


### PR DESCRIPTION
Ensure consistent 'Back' and 'Confirm Payment' button layout on the Attendant Workflow's transaction ID entry step.

Previously, the `ActionBar` incorrectly hid the main action button on step 5, leading to only a 'Back' button being visible. This PR refactors the payment step to consistently display both 'Back' and 'Confirm Payment' buttons, supporting both QR code scanning and manual transaction ID entry as per user requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed7e36b8-3e20-4574-b3e1-e52d35ebca8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed7e36b8-3e20-4574-b3e1-e52d35ebca8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

