### PR TITLE
Update receipt display for amount due and paid

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -3274,6 +3274,8 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
             swapData={swapData} 
             customerData={customerData} 
             transactionId={transactionId}
+            amountDue={swapData.cost}
+            amountPaid={actualAmountPaid}
           />
         );
       default:

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step6Success.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step6Success.tsx
@@ -8,9 +8,19 @@ interface Step6Props {
   swapData: SwapData;
   customerData: CustomerData | null;
   transactionId: string;
+  amountDue: number;  // Expected payment amount
+  amountPaid: number; // Actual amount paid by customer
+  currencySymbol?: string;
 }
 
-export default function Step6Success({ swapData, customerData, transactionId }: Step6Props) {
+export default function Step6Success({ 
+  swapData, 
+  customerData, 
+  transactionId,
+  amountDue,
+  amountPaid,
+  currencySymbol = 'KES'
+}: Step6Props) {
   const { t } = useI18n();
   
   return (
@@ -26,7 +36,7 @@ export default function Step6Success({ swapData, customerData, transactionId }: 
         
         <div className="receipt-card">
           <div className="receipt-header">
-            <span className="receipt-title">{t('attendant.transactionId')}</span>
+            <span className="receipt-title">{t('attendant.transactionReceipt') || 'Transaction Receipt'}</span>
             <span className="receipt-id">#{transactionId}</span>
           </div>
           <div className="receipt-row">
@@ -34,29 +44,35 @@ export default function Step6Success({ swapData, customerData, transactionId }: 
             <span className="receipt-value">{customerData?.name || 'Customer'}</span>
           </div>
           <div className="receipt-row">
-            <span className="receipt-label">{t('attendant.returnedBattery')}</span>
+            <span className="receipt-label">{t('attendant.returned') || 'Returned'}</span>
             <span className="receipt-value">
-              {swapData.oldBattery?.shortId || '---'} ({((swapData.oldBattery?.energy || 0) / 1000).toFixed(3)} kWh)
+              {swapData.oldBattery?.shortId || '---'} ({swapData.oldBattery?.chargeLevel ?? 0}%)
             </span>
           </div>
           <div className="receipt-row">
-            <span className="receipt-label">{t('attendant.issuedBattery')}</span>
+            <span className="receipt-label">{t('attendant.issued') || 'Issued'}</span>
             <span className="receipt-value">
-              {swapData.newBattery?.shortId || '---'} ({((swapData.newBattery?.energy || 0) / 1000).toFixed(3)} kWh)
+              {swapData.newBattery?.shortId || '---'} ({swapData.newBattery?.chargeLevel ?? 0}%)
             </span>
           </div>
           <div className="receipt-row">
-            <span className="receipt-label">{t('attendant.energyDiff')}</span>
-            <span className="receipt-value">{swapData.energyDiff.toFixed(3)} kWh</span>
+            <span className="receipt-label">{t('attendant.energy') || 'Energy'}</span>
+            <span className="receipt-value">{swapData.energyDiff.toFixed(2)} kWh</span>
           </div>
           <div className="receipt-row">
             <span className="receipt-label">{t('sales.amountDue')}</span>
-            <span className="receipt-value" style={{ color: 'var(--success)' }}>
-              KES {swapData.cost.toFixed(2)}
+            <span className="receipt-value">
+              {currencySymbol} {amountDue.toFixed(0)}
             </span>
           </div>
           <div className="receipt-row">
-            <span className="receipt-label">Time</span>
+            <span className="receipt-label">{t('sales.amountPaid')}</span>
+            <span className="receipt-value" style={{ color: 'var(--success)' }}>
+              {currencySymbol} {amountPaid.toFixed(0)}
+            </span>
+          </div>
+          <div className="receipt-row">
+            <span className="receipt-label">{t('attendant.time') || 'Time'}</span>
             <span className="receipt-value">{new Date().toLocaleTimeString()}</span>
           </div>
         </div>

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step6Success.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step6Success.tsx
@@ -25,19 +25,22 @@ export default function Step6Success({
   
   return (
     <div className="screen active">
-      <div className="success-screen">
+      <div className="success-screen" style={{ paddingTop: '12px' }}>
         <div className="success-icon">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
             <path d="M20 6L9 17l-5-5"/>
           </svg>
         </div>
         <h2 className="success-title">{t('attendant.swapComplete')}</h2>
-        <p className="success-message">{t('attendant.batteryIssued')}</p>
+        <p className="success-message">
+          {t('attendant.handOverBattery') || `Hand over ${swapData.newBattery?.shortId || 'battery'} to customer`}
+        </p>
         
-        <div className="receipt-card">
+        {/* Receipt Card - Full width with left-aligned text */}
+        <div className="receipt-card" style={{ width: '100%', textAlign: 'left' }}>
           <div className="receipt-header">
             <span className="receipt-title">{t('attendant.transactionReceipt') || 'Transaction Receipt'}</span>
-            <span className="receipt-id">#{transactionId}</span>
+            <span className="receipt-id font-mono-oves">#{transactionId}</span>
           </div>
           <div className="receipt-row">
             <span className="receipt-label">{t('attendant.step.customer')}</span>
@@ -45,35 +48,35 @@ export default function Step6Success({
           </div>
           <div className="receipt-row">
             <span className="receipt-label">{t('attendant.returned') || 'Returned'}</span>
-            <span className="receipt-value">
+            <span className="receipt-value font-mono-oves">
               {swapData.oldBattery?.shortId || '---'} ({swapData.oldBattery?.chargeLevel ?? 0}%)
             </span>
           </div>
           <div className="receipt-row">
             <span className="receipt-label">{t('attendant.issued') || 'Issued'}</span>
-            <span className="receipt-value">
+            <span className="receipt-value font-mono-oves">
               {swapData.newBattery?.shortId || '---'} ({swapData.newBattery?.chargeLevel ?? 0}%)
             </span>
           </div>
           <div className="receipt-row">
             <span className="receipt-label">{t('attendant.energy') || 'Energy'}</span>
-            <span className="receipt-value">{swapData.energyDiff.toFixed(2)} kWh</span>
+            <span className="receipt-value font-mono-oves">{swapData.energyDiff.toFixed(2)} kWh</span>
           </div>
           <div className="receipt-row">
             <span className="receipt-label">{t('sales.amountDue')}</span>
-            <span className="receipt-value">
-              {currencySymbol} {amountDue.toFixed(0)}
+            <span className="receipt-value font-mono-oves">
+              {currencySymbol} {amountDue.toLocaleString()}
             </span>
           </div>
           <div className="receipt-row">
             <span className="receipt-label">{t('sales.amountPaid')}</span>
-            <span className="receipt-value" style={{ color: 'var(--success)' }}>
-              {currencySymbol} {amountPaid.toFixed(0)}
+            <span className="receipt-value font-mono-oves" style={{ color: 'var(--success)' }}>
+              {currencySymbol} {amountPaid.toLocaleString()}
             </span>
           </div>
           <div className="receipt-row">
             <span className="receipt-label">{t('attendant.time') || 'Time'}</span>
-            <span className="receipt-value">{new Date().toLocaleTimeString()}</span>
+            <span className="receipt-value font-mono-oves">{new Date().toLocaleTimeString()}</span>
           </div>
         </div>
       </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1110,6 +1110,7 @@
   
   "attendant.swapComplete": "Swap Complete!",
   "attendant.batteryIssued": "Battery has been issued successfully",
+  "attendant.handOverBattery": "Hand over battery to customer",
   "attendant.transactionId": "Transaction ID",
   "attendant.transactionReceipt": "Transaction Receipt",
   "attendant.returned": "Returned",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1111,5 +1111,10 @@
   "attendant.swapComplete": "Swap Complete!",
   "attendant.batteryIssued": "Battery has been issued successfully",
   "attendant.transactionId": "Transaction ID",
+  "attendant.transactionReceipt": "Transaction Receipt",
+  "attendant.returned": "Returned",
+  "attendant.issued": "Issued",
+  "attendant.energy": "Energy",
+  "attendant.time": "Time",
   "attendant.startNewSwap": "Start New Swap"
 }

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1101,6 +1101,7 @@
   
   "attendant.swapComplete": "Échange terminé !",
   "attendant.batteryIssued": "La batterie a été émise avec succès",
+  "attendant.handOverBattery": "Remettre la batterie au client",
   "attendant.transactionId": "ID de transaction",
   "attendant.transactionReceipt": "Reçu de transaction",
   "attendant.returned": "Retournée",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1102,5 +1102,10 @@
   "attendant.swapComplete": "Échange terminé !",
   "attendant.batteryIssued": "La batterie a été émise avec succès",
   "attendant.transactionId": "ID de transaction",
+  "attendant.transactionReceipt": "Reçu de transaction",
+  "attendant.returned": "Retournée",
+  "attendant.issued": "Émise",
+  "attendant.energy": "Énergie",
+  "attendant.time": "Heure",
   "attendant.startNewSwap": "Nouvel échange"
 }

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1012,6 +1012,11 @@
   
   "attendant.swapComplete": "更换完成！",
   "attendant.batteryIssued": "电池已成功发放",
+  "attendant.transactionReceipt": "交易收据",
+  "attendant.returned": "退回",
+  "attendant.issued": "发放",
+  "attendant.energy": "能量",
+  "attendant.time": "时间",
   "attendant.transactionId": "交易ID",
   "attendant.startNewSwap": "开始新的更换"
 }

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1012,6 +1012,7 @@
   
   "attendant.swapComplete": "更换完成！",
   "attendant.batteryIssued": "电池已成功发放",
+  "attendant.handOverBattery": "将电池交给客户",
   "attendant.transactionReceipt": "交易收据",
   "attendant.returned": "退回",
   "attendant.issued": "发放",


### PR DESCRIPTION
Refactor the receipt screen in Attendant Workflow to match the design, display both amount due and amount paid, and improve layout.

The previous receipt screen had a poor layout due to centering styles and only displayed the amount due. This PR explicitly shows both the expected amount (amount due) and the actual amount paid, updates battery information to charge percentage, and adjusts the card's styling to align with design specifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-465058e9-f84d-4918-bcce-f750ff821e78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-465058e9-f84d-4918-bcce-f750ff821e78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

