### PR TITLE
Investigate sales person redirect to ble device manager

### DIFF
--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -40,7 +40,7 @@ export const isAuthenticated = (): boolean => {
   return getDecodedToken() !== null;
 };
 
-const PUBLIC_ROUTES = ["/keypad", "/signin", "/signup", "/rider", "/attendant"] as const;
+const PUBLIC_ROUTES = ["/keypad", "/signin", "/signup", "/rider", "/attendant", "/customers"] as const;
 
 export function isAuth(Component: any) {
   return function ProtectedPage(props: any) {


### PR DESCRIPTION
Add `/customers` to `PUBLIC_ROUTES` to ensure the Sales Person workflow uses the correct login page and shares authentication with the Attendant workflow.

Previously, clicking on "Sales Person" redirected to the BLE Device Manager login because `/customers` was not in `PUBLIC_ROUTES`. This change allows the Sales flow to handle its own authentication, using the same "Staff Login" page as Attendant and leveraging shared employee credentials.

---
<a href="https://cursor.com/background-agent?bcId=bc-90f2bcef-8bab-4711-b714-eb8c92945030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90f2bcef-8bab-4711-b714-eb8c92945030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

