### PR TITLE
Log order creation request and response

### DIFF
--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -1485,8 +1485,16 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
           if (subscriptionCode) {
             // Initiate payment to send M-Pesa prompt
             // Pass the subscription code directly to avoid React state timing issues
-            await initiateOdooPayment(subscriptionCode);
-            advanceToStep(5);
+            const paymentInitiatedSuccess = await initiateOdooPayment(subscriptionCode);
+            
+            // Only advance to payment step if payment request was created successfully
+            if (paymentInitiatedSuccess) {
+              advanceToStep(5);
+            } else {
+              // Payment request creation failed - don't proceed
+              // Error toast already shown by initiateOdooPayment
+              console.error('Payment request creation failed - not advancing to payment step');
+            }
           }
         } finally {
           setIsProcessing(false);

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -39,10 +39,8 @@ import {
 import {
   registerCustomer,
   getSubscriptionProducts,
-  purchaseSubscription,
   purchaseMultiProducts,
   initiatePayment,
-  createPaymentRequest,
   confirmPaymentManual,
   getCycleUnitFromPeriod,
   DEFAULT_COMPANY_ID,
@@ -152,7 +150,7 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
   const [paymentReference, setPaymentReference] = useState<string>('');
   const [paymentInitiated, setPaymentInitiated] = useState(false);
   const [paymentInputMode, setPaymentInputMode] = useState<'scan' | 'manual'>('scan');
-  // Payment request order ID - REQUIRED for confirm payment (from createPaymentRequest response)
+  // Order ID - REQUIRED for confirm payment (from purchaseMultiProducts response)
   const [paymentRequestOrderId, setPaymentRequestOrderId] = useState<number | null>(null);
   
   // Payment amount tracking for incomplete payments
@@ -1102,8 +1100,9 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
   }, [formData]);
 
   // Purchase subscription after customer is registered
-  // Returns the subscription code on success, null on failure
-  const purchaseCustomerSubscription = useCallback(async (): Promise<string | null> => {
+  // Returns object with subscription_code and order_id on success, null on failure
+  // The order is created automatically by /api/subscription/purchase endpoint
+  const purchaseCustomerSubscription = useCallback(async (): Promise<{ subscriptionCode: string; orderId: number } | null> => {
     if (!createdPartnerId) {
       toast.error('Customer not registered yet');
       return null;
@@ -1171,10 +1170,11 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
       console.log('Purchasing package + subscription:', purchasePayload);
 
       // Use the multi-product purchase endpoint
+      // This endpoint creates both the subscription AND the order automatically
       const response = await purchaseMultiProducts(purchasePayload, employeeToken || undefined);
 
       if (response.success && response.data && response.data.subscription) {
-        const { subscription } = response.data;
+        const { subscription, order } = response.data;
         
         setSubscriptionData({
           id: subscription.id,
@@ -1186,10 +1186,27 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
           currencySymbol: subscription.currency_symbol,
         });
         
+        // Store the order_id from purchase response - this is used for payment confirmation
+        // No need to call createPaymentRequest since order is already created
+        if (order && order.id) {
+          console.info('=== ORDER CREATED BY PURCHASE ENDPOINT ===');
+          console.info('Order ID:', order.id);
+          console.info('Order Name:', order.name);
+          console.info('Order State:', order.state);
+          console.info('Order Amount:', order.amount_total);
+          setPaymentRequestOrderId(order.id);
+        } else {
+          console.warn('No order returned from purchase endpoint');
+        }
+        
         console.log('Subscription purchased:', subscription);
         toast.success('Order created!');
-        // Return the subscription code directly so caller doesn't have to wait for state update
-        return subscription.subscription_code;
+        
+        // Return both subscription code and order_id
+        return {
+          subscriptionCode: subscription.subscription_code,
+          orderId: order?.id || 0,
+        };
       } else {
         throw new Error('Order creation failed');
       }
@@ -1200,9 +1217,9 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
     }
   }, [createdPartnerId, selectedPackageId, availablePackages, selectedPlanId, availablePlans]);
 
-  // Initiate payment with Odoo before collecting M-Pesa
-  // Step 1: Create payment request/ticket FIRST (REQUIRED)
-  // Step 2: Optionally send STK push to customer's phone
+  // Initiate payment with Odoo - send STK push to customer's phone
+  // NOTE: For Sales flow, the order is already created by /api/subscription/purchase
+  // We just need to send the STK push and mark payment as initiated
   // Accepts optional subscriptionCode parameter to avoid React state timing issues
   const initiateOdooPayment = useCallback(async (subscriptionCode?: string): Promise<boolean> => {
     // Use the passed subscription code, or fall back to state
@@ -1212,6 +1229,18 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
       toast.error('No subscription created. Please try again.');
       return false;
     }
+
+    // Verify we have an order_id from the purchase response
+    // This was set by purchaseCustomerSubscription when the order was created
+    if (!paymentRequestOrderId) {
+      console.error('No order_id from purchase response - cannot proceed with payment');
+      toast.error('Order not created properly. Please try again.');
+      return false;
+    }
+
+    console.info('=== SALES FLOW - INITIATING PAYMENT ===');
+    console.info('Order ID (from purchase):', paymentRequestOrderId);
+    console.info('Subscription Code:', subCode);
 
     // Get the salesperson's employee token for authorization
     const employeeToken = getEmployeeToken();
@@ -1233,47 +1262,11 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
     phoneNumber = phoneNumber.replace('+', '');
 
     try {
-      // Build descriptive payment description
-      const packageName = currentSelectedPackage?.name || 'Package';
-      const subscriptionName = currentSelectedPlan?.name || 'Subscription';
-      const description = `${packageName} + ${subscriptionName}`;
-      
-      // Step 1: Create payment request/ticket FIRST (REQUIRED)
-      // This gives us the order_id needed for confirm payment
-      console.log('Creating payment request with Odoo:', {
-        subscription_code: subCode,
-        amount_required: totalAmount,
-        description,
-      });
+      // Order is already created by /api/subscription/purchase endpoint
+      // No need to call createPaymentRequest - just send STK push
+      toast.success('Order ready. Collect payment from customer.');
 
-      const paymentRequestResponse = await createPaymentRequest({
-        subscription_code: subCode,
-        amount_required: totalAmount,
-        description,
-      });
-
-      if (paymentRequestResponse.success && paymentRequestResponse.payment_request) {
-        // Payment request created successfully - store the order_id
-        console.log('Payment request created:', paymentRequestResponse.payment_request);
-        setPaymentRequestOrderId(paymentRequestResponse.payment_request.sale_order.id);
-        toast.success('Payment ticket created. Collect payment from customer.');
-      } else {
-        // Payment request creation failed - show error to user
-        console.error('Payment request creation failed:', paymentRequestResponse.error);
-        
-        let errorMessage = paymentRequestResponse.error || 'Failed to create payment request';
-        
-        // If there's an existing request, include details about it
-        if (paymentRequestResponse.existing_request) {
-          const existingReq = paymentRequestResponse.existing_request;
-          errorMessage = `${paymentRequestResponse.message || errorMessage}\n\nExisting request: KES ${existingReq.amount_remaining} remaining (${existingReq.status})`;
-        }
-        
-        toast.error(errorMessage);
-        return false;
-      }
-
-      // Step 2: Optionally try to send STK push (don't block if it fails)
+      // Optionally try to send STK push (don't block if it fails)
       if (phoneNumber) {
         try {
           console.log('Sending STK push to customer phone:', phoneNumber);
@@ -1296,11 +1289,11 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
       setPaymentInitiated(true);
       return true;
     } catch (error: any) {
-      console.error('Failed to create payment request:', error);
-      toast.error(error.message || 'Failed to create payment request. Please try again.');
+      console.error('Failed to initiate payment:', error);
+      toast.error(error.message || 'Failed to initiate payment. Please try again.');
       return false;
     }
-  }, [subscriptionData, selectedPackageId, availablePackages, selectedPlanId, availablePlans, formData.phone]);
+  }, [subscriptionData, selectedPackageId, availablePackages, selectedPlanId, availablePlans, formData.phone, paymentRequestOrderId]);
 
   // Handle payment confirmation via QR scan
   const handlePaymentQrScan = useCallback(async () => {
@@ -1327,9 +1320,9 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
         }
       }
 
-      // order_id is REQUIRED - must be obtained from createPaymentRequest response
+      // order_id is REQUIRED - obtained from purchaseMultiProducts response
       if (!paymentRequestOrderId) {
-        toast.error('Payment request not created. Please go back and try again.');
+        toast.error('Order not created. Please go back and try again.');
         setIsProcessing(false);
         return;
       }
@@ -1478,22 +1471,28 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
         advanceToStep(4);
         break;
       case 4:
-        // Preview step - Purchase subscription and move to payment step
+        // Preview step - Purchase subscription (order is created automatically) and move to payment step
         setIsProcessing(true);
         try {
-          const subscriptionCode = await purchaseCustomerSubscription();
-          if (subscriptionCode) {
+          // purchaseCustomerSubscription creates the order via /api/subscription/purchase
+          // It returns both subscriptionCode and orderId
+          const purchaseResult = await purchaseCustomerSubscription();
+          if (purchaseResult) {
+            console.info('=== PURCHASE SUCCESSFUL ===');
+            console.info('Subscription Code:', purchaseResult.subscriptionCode);
+            console.info('Order ID:', purchaseResult.orderId);
+            
             // Initiate payment to send M-Pesa prompt
             // Pass the subscription code directly to avoid React state timing issues
-            const paymentInitiatedSuccess = await initiateOdooPayment(subscriptionCode);
+            const paymentInitiatedSuccess = await initiateOdooPayment(purchaseResult.subscriptionCode);
             
-            // Only advance to payment step if payment request was created successfully
+            // Only advance to payment step if payment initiation was successful
             if (paymentInitiatedSuccess) {
               advanceToStep(5);
             } else {
-              // Payment request creation failed - don't proceed
+              // Payment initiation failed - don't proceed
               // Error toast already shown by initiateOdooPayment
-              console.error('Payment request creation failed - not advancing to payment step');
+              console.error('Payment initiation failed - not advancing to payment step');
             }
           }
         } finally {

--- a/src/lib/odoo-api.ts
+++ b/src/lib/odoo-api.ts
@@ -627,16 +627,34 @@ export async function purchaseMultiProducts(
       body: JSON.stringify(payload),
     });
 
-    const rawData: PurchaseSubscriptionRawResponse = await response.json();
+    const rawData = await response.json();
 
     // Log the full response for debugging
     console.info('=== PURCHASE MULTI PRODUCTS (CREATE ORDER) - RESPONSE ===');
     console.info('HTTP Status:', response.status);
     console.info('Response:', JSON.stringify(rawData, null, 2));
 
+    // Check HTTP status first
     if (!response.ok) {
-      console.error('Odoo API Error:', rawData);
-      throw new Error((rawData as any)?.message || (rawData as any)?.error || `HTTP ${response.status}`);
+      console.error('Odoo API Error (HTTP):', rawData);
+      throw new Error(rawData?.message || rawData?.error || `HTTP ${response.status}`);
+    }
+
+    // Check success field - API might return HTTP 200 with success: false
+    if (!rawData.success) {
+      console.error('Odoo API Error (success=false):', rawData);
+      throw new Error(rawData?.message || rawData?.error || 'Order creation failed');
+    }
+
+    // Validate required fields exist
+    if (!rawData.order || !rawData.order.id) {
+      console.error('Odoo API Error: Missing order in response', rawData);
+      throw new Error('Order creation failed - no order returned');
+    }
+
+    if (!rawData.subscription || !rawData.subscription.subscription_code) {
+      console.error('Odoo API Error: Missing subscription in response', rawData);
+      throw new Error('Order creation failed - no subscription returned');
     }
 
     // Get currency symbol based on currency code
@@ -653,8 +671,9 @@ export async function purchaseMultiProducts(
     };
 
     // Transform root-level response to normalized format with data wrapper
+    // Note: order_id is also available at root level as rawData.order_id
     return {
-      success: rawData.success,
+      success: true,
       data: {
         subscription: {
           id: rawData.subscription.subscription_id,
@@ -670,7 +689,8 @@ export async function purchaseMultiProducts(
       },
     };
   } catch (error: any) {
-    console.error('Odoo API Request Failed:', error);
+    console.error('=== PURCHASE MULTI PRODUCTS - ERROR ===');
+    console.error('Error:', error);
     throw error;
   }
 }

--- a/src/lib/odoo-api.ts
+++ b/src/lib/odoo-api.ts
@@ -615,6 +615,11 @@ export async function purchaseMultiProducts(
     headers['Authorization'] = `Bearer ${authToken}`;
   }
 
+  // Log the request payload for debugging
+  console.info('=== PURCHASE MULTI PRODUCTS (CREATE ORDER) - PAYLOAD ===');
+  console.info('URL:', url);
+  console.info('Payload:', JSON.stringify(payload, null, 2));
+
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -623,6 +628,11 @@ export async function purchaseMultiProducts(
     });
 
     const rawData: PurchaseSubscriptionRawResponse = await response.json();
+
+    // Log the full response for debugging
+    console.info('=== PURCHASE MULTI PRODUCTS (CREATE ORDER) - RESPONSE ===');
+    console.info('HTTP Status:', response.status);
+    console.info('Response:', JSON.stringify(rawData, null, 2));
 
     if (!response.ok) {
       console.error('Odoo API Error:', rawData);
@@ -754,6 +764,11 @@ export async function createPaymentRequest(
     headers['Authorization'] = `Bearer ${authToken}`;
   }
   
+  // Log the request payload for debugging
+  console.info('=== CREATE PAYMENT REQUEST - PAYLOAD ===');
+  console.info('URL:', url);
+  console.info('Payload:', JSON.stringify(payload, null, 2));
+  
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -763,11 +778,17 @@ export async function createPaymentRequest(
     
     const data: CreatePaymentRequestResponse = await response.json();
     
+    // Log the full response for debugging
+    console.info('=== CREATE PAYMENT REQUEST - RESPONSE ===');
+    console.info('HTTP Status:', response.status);
+    console.info('Response:', JSON.stringify(data, null, 2));
+    
     // Note: API returns success: false for business rule violations (e.g., existing active request)
     // We return the full response so caller can handle accordingly
     return data;
   } catch (error: any) {
-    console.error('Create payment request failed:', error);
+    console.error('=== CREATE PAYMENT REQUEST - ERROR ===');
+    console.error('Error:', error);
     throw error;
   }
 }


### PR DESCRIPTION
Add logging for Odoo order and payment request creation, and fix a bug where the app proceeded to payment confirmation despite payment request failure.

The `initiateOdooPayment` function's return value was not checked, causing the `SalesFlow` to incorrectly advance to the payment confirmation step even when the payment request failed. This fix prevents proceeding to the payment step if the payment request creation is unsuccessful.

---
<a href="https://cursor.com/background-agent?bcId=bc-4432da97-6a71-4944-8a6d-772066859bcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4432da97-6a71-4944-8a6d-772066859bcf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

