### PR TITLE
Remove deal section from package cards

### DIFF
--- a/src/app/(mobile)/customers/customerform/components/steps/Step2SelectPackage.tsx
+++ b/src/app/(mobile)/customers/customerform/components/steps/Step2SelectPackage.tsx
@@ -190,14 +190,6 @@ export default function Step2SelectPackage({
                   </svg>
                 </div>
                 
-                {/* Package badge */}
-                <div className="package-badge">
-                  <svg viewBox="0 0 24 24" fill="currentColor" width="10" height="10">
-                    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
-                  </svg>
-                  <span>{t('sales.deal') || 'Deal'}</span>
-                </div>
-                
                 {/* Product image */}
                 <div className="vehicle-image-wrapper">
                   {hasImage ? (


### PR DESCRIPTION
Remove the 'Deal' badge from package cards on the Select Package Page as it's not required for the Sales Person Workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8ea92ac-1331-4520-b862-a40c9a20b7a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8ea92ac-1331-4520-b862-a40c9a20b7a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

