### PR TITLE
Debug attendant workflow connection issue

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -287,9 +287,6 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
   // Ref for tracking current scan type
   const scanTypeRef = useRef<'customer' | 'old_battery' | 'new_battery' | 'payment' | null>(null);
   
-  // Bridge initialization ref (for preventing double init() calls)
-  const bridgeInitRef = useRef<boolean>(false);
-  
   // Track if QR scan was initiated to detect when user returns without scanning
   const qrScanInitiatedRef = useRef<boolean>(false);
   
@@ -1119,14 +1116,8 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
       return () => b.registerHandler(name, noop);
     };
 
-    if (!bridgeInitRef.current) {
-      bridgeInitRef.current = true;
-      try {
-        b.init((_m, r) => r("js success!"));
-      } catch (err) {
-        console.error("Bridge init error", err);
-      }
-    }
+    // NOTE: bridge.init() is already called in bridgeContext.tsx
+    // Do NOT call init() again here as it causes the app to hang
 
     // QR code scan callback - follows existing pattern from swap.tsx
     const offQr = reg(

--- a/src/app/(mobile)/attendant/attendant/swap.tsx
+++ b/src/app/(mobile)/attendant/attendant/swap.tsx
@@ -230,8 +230,6 @@ const Swap: React.FC<SwapProps> = ({ customer }) => {
     setCalculatedPaymentAmount(calculatePaymentAmount);
   }, [calculatePaymentAmount]);
 
-  
-  const bridgeInitRef = useRef(false);
   const scanTypeRef = useRef<
     "customer" | "equipment" | "checkin" | "checkout" | "payment" | null
   >(null);
@@ -1320,14 +1318,8 @@ const deriveCustomerTypeFromPayload = (payload?: any) => {
         return () => b.registerHandler(name, noop);
       };
 
-      if (!bridgeInitRef.current) {
-        bridgeInitRef.current = true;
-        try {
-          b.init((_m, r) => r("js success!"));
-        } catch (err) {
-          console.error("Bridge init error", err);
-        }
-      }
+      // NOTE: bridge.init() is already called in bridgeContext.tsx
+      // Do NOT call init() again here as it causes the app to hang
 
       // MQTT message callback for echo/# responses
       const offMqttRecv = reg(

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -515,14 +515,8 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
       }
       bridgeInitRef.current = true;
 
-      // Wrap init in try-catch to handle case where BridgeContext already called init()
-      try {
-        window.WebViewJavascriptBridge.init((message: any, responseCallback: (response: any) => void) => {
-          responseCallback({ success: true });
-        });
-      } catch (err) {
-        // Bridge was already initialized by BridgeContext - this is expected
-      }
+      // NOTE: bridge.init() is already called in bridgeContext.tsx
+      // Do NOT call init() again here as it causes the app to hang
 
       // QR Code result handler - MUST match Attendant flow handler name
       // The scanner returns JSON with respData.value containing the actual QR code text

--- a/src/lib/hooks/ble/useBleDeviceConnection.ts
+++ b/src/lib/hooks/ble/useBleDeviceConnection.ts
@@ -241,12 +241,8 @@ export function useBleDeviceConnection(options: UseBleDeviceConnectionOptions = 
 
       log('Setting up connection handlers');
 
-      // Try to init bridge
-      try {
-        window.WebViewJavascriptBridge.init((_m, r) => r('js success!'));
-      } catch {
-        // Already initialized
-      }
+      // NOTE: bridge.init() is already called in bridgeContext.tsx
+      // Do NOT call init() again here as it causes the app to hang
 
       // Connection success handler
       window.WebViewJavascriptBridge.registerHandler(

--- a/src/lib/hooks/ble/useBleDeviceScanner.ts
+++ b/src/lib/hooks/ble/useBleDeviceScanner.ts
@@ -174,12 +174,8 @@ export function useBleDeviceScanner(options: UseBleDeviceScannerOptions = {}) {
 
       log('Setting up BLE scanner handler');
 
-      // Try to init bridge (may already be initialized)
-      try {
-        window.WebViewJavascriptBridge.init((_m, r) => r('js success!'));
-      } catch {
-        // Already initialized
-      }
+      // NOTE: bridge.init() is already called in bridgeContext.tsx
+      // Do NOT call init() again here as it causes the app to hang
 
       // Device discovery handler
       window.WebViewJavascriptBridge.registerHandler(

--- a/src/lib/hooks/ble/useBleServiceReader.ts
+++ b/src/lib/hooks/ble/useBleServiceReader.ts
@@ -197,12 +197,8 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
 
       log('Setting up service reader handlers');
 
-      // Try to init bridge
-      try {
-        window.WebViewJavascriptBridge.init((_m, r) => r('js success!'));
-      } catch {
-        // Already initialized
-      }
+      // NOTE: bridge.init() is already called in bridgeContext.tsx
+      // Do NOT call init() again here as it causes the app to hang
 
       // Progress handler
       window.WebViewJavascriptBridge.registerHandler(

--- a/src/lib/hooks/useBleConnection.ts
+++ b/src/lib/hooks/useBleConnection.ts
@@ -537,12 +537,8 @@ export function useBleConnection(options: BleConnectionOptions = {}) {
 
       log('Setting up BLE bridge handlers');
 
-      // Wrap init in try-catch (BridgeContext may have already called it)
-      try {
-        window.WebViewJavascriptBridge.init((_m, r) => r('js success!'));
-      } catch {
-        // Already initialized
-      }
+      // NOTE: bridge.init() is already called in bridgeContext.tsx
+      // Do NOT call init() again here as it causes the app to hang
 
       // ============================================
       // DEVICE DISCOVERY HANDLER


### PR DESCRIPTION
Remove duplicate `bridge.init()` calls to fix app hangs.

The `WebViewJavascriptBridge.init()` function should only be called once. Multiple calls were causing the bridge to re-initialize and hang, particularly when entering the Attendant Workflow and using BLE-related hooks.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a1a8f82-0c7e-4a46-8c4c-6346e9ff9942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0a1a8f82-0c7e-4a46-8c4c-6346e9ff9942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

