### PR TITLE
Refactor ble and fix ui issues

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/ScannerArea.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/ScannerArea.tsx
@@ -1,18 +1,24 @@
 'use client';
 
 import React from 'react';
+import { useI18n } from '@/i18n';
 
 interface ScannerAreaProps {
   onClick: () => void;
   type?: 'qr' | 'battery'; // Kept for backward compatibility, but all types use same QR icon
   size?: 'normal' | 'small'; // Deprecated - all scanners now use consistent size
   disabled?: boolean; // Prevent clicks while scanner is opening
+  label?: string; // Custom label for the scanner prompt
 }
 
-export default function ScannerArea({ onClick, disabled = false }: ScannerAreaProps) {
+export default function ScannerArea({ onClick, disabled = false, label }: ScannerAreaProps) {
+  const { t } = useI18n();
   // Consistent size for all scan areas in the Attendant workflow
   // Using 140x140px as a balanced size that works well across all steps
   const consistentStyle = { width: '140px', height: '140px', margin: '16px auto' };
+  
+  // Use provided label or fall back to translated text or default
+  const displayLabel = label || t('common.tapToScan') || 'Tap to scan';
 
   const handleClick = () => {
     // Prevent triggering if disabled (scanner already opening)
@@ -57,7 +63,7 @@ export default function ScannerArea({ onClick, disabled = false }: ScannerAreaPr
             </div>
             {/* Clear prompt so users know to tap */}
             <div className="scanner-tap-prompt">
-              <span>Tap to scan</span>
+              <span>{displayLabel}</span>
             </div>
           </>
         )}

--- a/src/components/shared/BleProgressModal.tsx
+++ b/src/components/shared/BleProgressModal.tsx
@@ -135,8 +135,11 @@ export function BleProgressModal({
             </div>
           )}
 
-          {/* Progress Bar - Hide when Bluetooth reset is required */}
-          {!bleScanState.requiresBluetoothReset && (
+          {/* Progress Bar - Only show real backend progress (not during retries or initial matching) */}
+          {/* Only show progress bar when actively connecting or reading, and progress is above initial state */}
+          {!bleScanState.requiresBluetoothReset && 
+           bleScanState.connectionProgress > 0 &&
+           (bleScanState.isConnecting || bleScanState.isReadingEnergy) && (
             <div className="ble-progress-bar-container">
               <div className="ble-progress-bar-bg">
                 <div 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -24,6 +24,7 @@
   "auth.error.invalidCredentials": "Invalid credentials",
   "auth.error.userNotFound": "User not found",
   "common.na": "N/A",
+  "common.tapToScan": "Tap to scan",
   "common.refresh": "Refresh",
   "common.description": "Description",
   "common.copied": "Value copied to clipboard",
@@ -1107,6 +1108,7 @@
   
   "attendant.returnBattery": "Return Battery",
   "attendant.scanReturnBattery": "Scan Return",
+  "attendant.scanReturnHint": "Scan the QR code on the battery being returned",
   "attendant.batteryReturned": "Battery Returned",
   "attendant.chargeLevel": "Charge Level",
   "attendant.energyRemaining": "Energy Remaining",
@@ -1115,6 +1117,7 @@
   
   "attendant.issueNewBattery": "Issue New Battery",
   "attendant.scanNewBattery": "Scan New",
+  "attendant.scanNewHint": "Scan the QR code on the new battery to issue",
   "attendant.newBatteryAssigned": "New Battery Assigned",
   "attendant.batteryId": "Battery ID",
   

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -24,6 +24,7 @@
   "auth.error.invalidCredentials": "Identifiants invalides",
   "auth.error.userNotFound": "Utilisateur introuvable",
   "common.na": "N/D",
+  "common.tapToScan": "Appuyez pour scanner",
   "common.refresh": "Rafraîchir",
   "common.description": "Description",
   "common.copied": "Valeur copiée dans le presse-papiers",
@@ -1098,6 +1099,7 @@
   
   "attendant.returnBattery": "Retourner la batterie",
   "attendant.scanReturnBattery": "Scanner Retour",
+  "attendant.scanReturnHint": "Scannez le code QR sur la batterie à retourner",
   "attendant.batteryReturned": "Batterie retournée",
   "attendant.chargeLevel": "Niveau de charge",
   "attendant.energyRemaining": "Énergie restante",
@@ -1106,6 +1108,7 @@
   
   "attendant.issueNewBattery": "Émettre une nouvelle batterie",
   "attendant.scanNewBattery": "Scanner Nouveau",
+  "attendant.scanNewHint": "Scannez le code QR sur la nouvelle batterie à émettre",
   "attendant.newBatteryAssigned": "Nouvelle batterie attribuée",
   "attendant.batteryId": "ID de la batterie",
   

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -24,6 +24,7 @@
   "auth.error.invalidCredentials": "凭证无效",
   "auth.error.userNotFound": "用户未找到",
   "common.na": "无",
+  "common.tapToScan": "点击扫描",
   "common.refresh": "刷新",
   "common.description": "描述",
   "common.copied": "已复制到剪贴板",
@@ -1009,6 +1010,7 @@
   
   "attendant.returnBattery": "归还电池",
   "attendant.scanReturnBattery": "扫描旧",
+  "attendant.scanReturnHint": "扫描要归还电池上的二维码",
   "attendant.batteryReturned": "电池已归还",
   "attendant.chargeLevel": "电量水平",
   "attendant.energyRemaining": "剩余能量",
@@ -1017,6 +1019,7 @@
   
   "attendant.issueNewBattery": "发放新电池",
   "attendant.scanNewBattery": "扫描新",
+  "attendant.scanNewHint": "扫描要发放新电池上的二维码",
   "attendant.newBatteryAssigned": "新电池已分配",
   "attendant.batteryId": "电池ID",
   


### PR DESCRIPTION
Refines BLE progress modal display and fixes translation issues for scanner area texts in the Attendant workflow.

The BLE progress bar now only shows actual backend connection/reading progress, preventing display during initial device matching or retries. Additionally, the "Tap to scan" text and specific scan hints are now correctly translated and displayed in the `ScannerArea` component by introducing new i18n keys and updating the component to use them.

---
<a href="https://cursor.com/background-agent?bcId=bc-30973057-bdb7-4a43-a888-553c655cb519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30973057-bdb7-4a43-a888-553c655cb519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

