### PR TITLE
Don't reset bluetooth connection timer

### DIFF
--- a/src/components/shared/BatteryScanBind.tsx
+++ b/src/components/shared/BatteryScanBind.tsx
@@ -450,17 +450,23 @@ function BleConnectionProgress({
   const [currentTipIndex, setCurrentTipIndex] = useState(0);
   const [countdown, setCountdown] = useState(COUNTDOWN_START_SECONDS);
   const [showCancelButton, setShowCancelButton] = useState(false);
-  const startTimeRef = useRef<number>(Date.now());
+  const startTimeRef = useRef<number | null>(null);
   
   // Track elapsed time and countdown
+  // IMPORTANT: Only initialize the timer once when component mounts.
+  // The 60s countdown is a contract with the customer - we don't reset it
+  // when transitioning between phases (e.g., connecting -> reading).
   useEffect(() => {
-    startTimeRef.current = Date.now();
-    setElapsedTime(0);
-    setCountdown(COUNTDOWN_START_SECONDS);
-    setShowCancelButton(false);
+    // Only set start time once when timer hasn't been initialized
+    if (startTimeRef.current === null) {
+      startTimeRef.current = Date.now();
+      setElapsedTime(0);
+      setCountdown(COUNTDOWN_START_SECONDS);
+      setShowCancelButton(false);
+    }
     
     const timer = setInterval(() => {
-      const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
+      const elapsed = Math.floor((Date.now() - (startTimeRef.current || Date.now())) / 1000);
       setElapsedTime(elapsed);
       
       const remaining = Math.max(0, COUNTDOWN_START_SECONDS - elapsed);


### PR DESCRIPTION
Prevent the Bluetooth connection countdown timer from resetting when transitioning between connection phases.

The 60-second timer is a contract with the customer for the entire connection process (connecting and data initialization), and should not restart when moving from the "connecting" phase to the "reading data" phase.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d420f79-1537-4b06-80f3-f5619134fd81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7d420f79-1537-4b06-80f3-f5619134fd81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

