### PR TITLE
Fix bluetooth connection modal bug

### DIFF
--- a/src/components/shared/BleProgressModal.tsx
+++ b/src/components/shared/BleProgressModal.tsx
@@ -51,12 +51,18 @@ export function BleProgressModal({
   // This prevents timer reset during transitions between Connect → Read stages
   useEffect(() => {
     if (!isModalVisible) {
-      // Modal is fully closed, reset everything for the next session
+      // Modal is fully closed, reset state for the next session
+      // NOTE: We do NOT reset hasTimedOut here! This is critical.
+      // If we reset hasTimedOut to false when the modal closes, and then
+      // connectionFailed becomes true (from a delayed BLE state update),
+      // the modal would reopen with "Cancel & Retry" even though we already
+      // auto-closed due to timeout. hasTimedOut is only reset when a new
+      // connection attempt genuinely starts (in the isActive effect below).
       startTimeRef.current = null;
       wasActiveRef.current = false;
       setCountdown(COUNTDOWN_START_SECONDS);
       setShowCancelButton(false);
-      setHasTimedOut(false);
+      // DO NOT reset hasTimedOut here - see note above
     }
   }, [isModalVisible]);
   


### PR DESCRIPTION
Remove `setHasTimedOut(false)` on modal close to prevent the "Cancel & Retry" modal from reappearing after the 60-second timeout.

The `hasTimedOut` state was being incorrectly reset to `false` when the modal became invisible, creating a race condition where a delayed `connectionFailed` state update would cause the modal to reopen.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2011878-2729-4e43-8d2a-232550fc89e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c2011878-2729-4e43-8d2a-232550fc89e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

