### PR TITLE
Fix plan card height

### DIFF
--- a/src/app/(mobile)/customers/customerform/components/steps/Step2SelectPlan.tsx
+++ b/src/app/(mobile)/customers/customerform/components/steps/Step2SelectPlan.tsx
@@ -90,28 +90,33 @@ export default function Step2SelectPlan({
                 showRadio
                 showCheck={false}
                 className="plan-card"
-                style={{ padding: '10px 12px' }}
+                style={{ padding: '10px 12px', minHeight: '56px' }}
               >
                 <div style={{ 
                   display: 'flex', 
                   alignItems: 'center', 
                   gap: '10px',
                   width: '100%',
+                  minHeight: '36px',
                 }}>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ 
                       fontWeight: 500, 
                       fontSize: '12px',
-                      marginBottom: '1px',
+                      marginBottom: plan.description ? '1px' : '0',
+                      lineHeight: '1.3',
                     }}>
                       {plan.name}
                     </div>
-                    <div style={{ 
-                      fontSize: '10px', 
-                      color: 'var(--text-muted, #5a8080)',
-                    }}>
-                      {plan.description}
-                    </div>
+                    {plan.description && (
+                      <div style={{ 
+                        fontSize: '10px', 
+                        color: 'var(--text-muted, #5a8080)',
+                        lineHeight: '1.3',
+                      }}>
+                        {plan.description}
+                      </div>
+                    )}
                   </div>
                   <div style={{ 
                     fontFamily: 'var(--font-mono)',

--- a/src/app/(mobile)/customers/customerform/components/steps/Step2SelectPlan.tsx
+++ b/src/app/(mobile)/customers/customerform/components/steps/Step2SelectPlan.tsx
@@ -90,33 +90,32 @@ export default function Step2SelectPlan({
                 showRadio
                 showCheck={false}
                 className="plan-card"
-                style={{ padding: '10px 12px', minHeight: '56px' }}
+                style={{ padding: '10px 12px', height: '56px' }}
               >
                 <div style={{ 
                   display: 'flex', 
                   alignItems: 'center', 
                   gap: '10px',
                   width: '100%',
-                  minHeight: '36px',
+                  height: '100%',
                 }}>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ 
                       fontWeight: 500, 
                       fontSize: '12px',
-                      marginBottom: plan.description ? '1px' : '0',
+                      marginBottom: '1px',
                       lineHeight: '1.3',
                     }}>
                       {plan.name}
                     </div>
-                    {plan.description && (
-                      <div style={{ 
-                        fontSize: '10px', 
-                        color: 'var(--text-muted, #5a8080)',
-                        lineHeight: '1.3',
-                      }}>
-                        {plan.description}
-                      </div>
-                    )}
+                    <div style={{ 
+                      fontSize: '10px', 
+                      color: 'var(--text-muted, #5a8080)',
+                      lineHeight: '1.3',
+                      height: '13px', /* Reserve space for description */
+                    }}>
+                      {plan.description || '\u00A0'} {/* Non-breaking space if no description */}
+                    </div>
                   </div>
                   <div style={{ 
                     fontFamily: 'var(--font-mono)',

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -185,6 +185,28 @@ export function SelectableCard({
   className = '',
   style,
 }: SelectableCardProps) {
+  const radioButton = showRadio ? (
+    <div style={{
+      width: 'var(--space-5)',
+      height: 'var(--space-5)',
+      borderRadius: 'var(--radius-full)',
+      border: `2px solid ${selected ? 'var(--color-brand)' : 'var(--border-default)'}`,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexShrink: 0,
+    }}>
+      {selected && (
+        <div style={{
+          width: 'var(--space-2-5)',
+          height: 'var(--space-2-5)',
+          borderRadius: 'var(--radius-full)',
+          backgroundColor: 'var(--color-brand)',
+        }} />
+      )}
+    </div>
+  ) : null;
+
   return (
     <Card 
       variant="outlined" 
@@ -210,29 +232,21 @@ export function SelectableCard({
           <CheckIcon size={14} color="var(--text-inverse)" strokeWidth={3} />
         </div>
       )}
-      {showRadio && (
+      {showRadio ? (
         <div style={{
-          width: 'var(--space-5)',
-          height: 'var(--space-5)',
-          borderRadius: 'var(--radius-full)',
-          border: `2px solid ${selected ? 'var(--color-brand)' : 'var(--border-default)'}`,
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
-          flexShrink: 0,
-          marginRight: 'var(--space-3)',
+          gap: 'var(--space-3)',
+          width: '100%',
         }}>
-          {selected && (
-            <div style={{
-              width: 'var(--space-2-5)',
-              height: 'var(--space-2-5)',
-              borderRadius: 'var(--radius-full)',
-              backgroundColor: 'var(--color-brand)',
-            }} />
-          )}
+          {radioButton}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            {children}
+          </div>
         </div>
+      ) : (
+        children
       )}
-      {children}
     </Card>
   );
 }


### PR DESCRIPTION
Fixes inconsistent plan card heights and radio button overlapping text on the "Select Plan" step to improve UI consistency and readability.

The `SelectableCard` component was rendering the radio button and children as siblings without a flex container, causing the radio button to appear above the content. This PR introduces a flex container to correctly position the radio button beside the content and adds minimum heights to plan cards for visual consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-8d01a627-d1e8-40a2-90b9-b34dabebd4ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8d01a627-d1e8-40a2-90b9-b34dabebd4ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

