### PR TITLE
Balance card heights on plan

### DIFF
--- a/src/app/(mobile)/customers/customerform/components/steps/Step2SelectPlan.tsx
+++ b/src/app/(mobile)/customers/customerform/components/steps/Step2SelectPlan.tsx
@@ -90,32 +90,43 @@ export default function Step2SelectPlan({
                 showRadio
                 showCheck={false}
                 className="plan-card"
-                style={{ padding: '10px 12px', height: '56px' }}
+                style={{ padding: '12px' }}
               >
                 <div style={{ 
                   display: 'flex', 
                   alignItems: 'center', 
+                  justifyContent: 'space-between',
                   gap: '10px',
                   width: '100%',
-                  height: '100%',
+                  minHeight: '32px', /* Consistent height for all cards */
                 }}>
-                  <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ 
+                    flex: 1, 
+                    minWidth: 0,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                  }}>
                     <div style={{ 
                       fontWeight: 500, 
                       fontSize: '12px',
-                      marginBottom: '1px',
                       lineHeight: '1.3',
                     }}>
                       {plan.name}
                     </div>
-                    <div style={{ 
-                      fontSize: '10px', 
-                      color: 'var(--text-muted, #5a8080)',
-                      lineHeight: '1.3',
-                      height: '13px', /* Reserve space for description */
-                    }}>
-                      {plan.description || '\u00A0'} {/* Non-breaking space if no description */}
-                    </div>
+                    {plan.description && (
+                      <div style={{ 
+                        fontSize: '10px', 
+                        color: 'var(--text-muted, #5a8080)',
+                        lineHeight: '1.3',
+                        marginTop: '2px',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}>
+                        {plan.description}
+                      </div>
+                    )}
                   </div>
                   <div style={{ 
                     fontFamily: 'var(--font-mono)',


### PR DESCRIPTION
Fixes layout issues on the 'My Select Plan' page to ensure all plan cards have consistent heights, center content, and handle description overflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc64d71d-a79d-48d6-8f7d-bfc63401ce9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc64d71d-a79d-48d6-8f7d-bfc63401ce9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

