### PR TITLE
Fix duplicate search inputs

### DIFF
--- a/src/components/shared/BatteryInputSelector.tsx
+++ b/src/components/shared/BatteryInputSelector.tsx
@@ -202,14 +202,14 @@ export default function BatteryInputSelector({
         </div>
       )}
 
-      {/* Compact Search Bar with integrated QR Scan - Like Keypad page */}
+      {/* Action Bar - QR Scan button with instruction text */}
       {!isFirstTimeCustomer && (
         <div className="battery-search-bar">
           <div className="battery-search-icon">
-            <SearchIcon />
+            <QrScanIcon />
           </div>
           <span className="battery-search-placeholder">
-            {t('battery.searchOrScan') || 'Search device or scan QR...'}
+            {t('common.scanOrSelect') || 'Scan QR code or select from list below'}
           </span>
           <button
             type="button"
@@ -237,6 +237,7 @@ export default function BatteryInputSelector({
             onSelectDevice={onDeviceSelect}
             onRescan={onStartScan}
             disabled={disabled}
+            hideSearch={true}
             maxHeight="320px"
           />
         </div>

--- a/src/components/shared/BleDeviceList.tsx
+++ b/src/components/shared/BleDeviceList.tsx
@@ -34,6 +34,8 @@ interface BleDeviceListProps {
   maxHeight?: string;
   /** Whether the list is disabled */
   disabled?: boolean;
+  /** Hide the internal search input (useful when parent provides search) */
+  hideSearch?: boolean;
   /** Optional className */
   className?: string;
 }
@@ -142,6 +144,7 @@ export default function BleDeviceList({
   subtitle,
   maxHeight = '300px',
   disabled = false,
+  hideSearch = false,
   className = '',
 }: BleDeviceListProps) {
   const { t } = useI18n();
@@ -190,8 +193,8 @@ export default function BleDeviceList({
         )}
       </div>
 
-      {/* Search */}
-      {devices.length > 3 && (
+      {/* Search - only show if not hidden by parent and there are enough devices */}
+      {!hideSearch && devices.length > 3 && (
         <div className="ble-device-search">
           <SearchIcon />
           <input

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -25,6 +25,7 @@
   "auth.error.userNotFound": "User not found",
   "common.na": "N/A",
   "common.or": "or select from list",
+  "common.scanOrSelect": "Scan QR code or select from list below",
   "common.tapToScan": "Tap to scan",
   "common.refresh": "Refresh",
   "common.description": "Description",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -25,6 +25,7 @@
   "auth.error.userNotFound": "Utilisateur introuvable",
   "common.na": "N/D",
   "common.or": "ou sélectionnez dans la liste",
+  "common.scanOrSelect": "Scannez le QR ou sélectionnez dans la liste ci-dessous",
   "common.tapToScan": "Appuyez pour scanner",
   "common.refresh": "Rafraîchir",
   "common.description": "Description",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -25,6 +25,7 @@
   "auth.error.userNotFound": "用户未找到",
   "common.na": "无",
   "common.or": "或从列表中选择",
+  "common.scanOrSelect": "扫描二维码或从下方列表中选择",
   "common.tapToScan": "点击扫描",
   "common.refresh": "刷新",
   "common.description": "描述",


### PR DESCRIPTION
Remove duplicate search input and fix placeholder text in `BatteryInputSelector` for a clearer user experience.

The "Return Battery" page displayed two search inputs due to `BatteryInputSelector` rendering its own search bar and also including `BleDeviceList`, which conditionally rendered another search bar. This PR resolves the duplication and corrects the placeholder text by centralizing the input and providing clear, translated instructions.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd291b83-624c-4ca7-8121-d4b895be6ec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd291b83-624c-4ca7-8121-d4b895be6ec3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

