### PR TITLE
Skip payment for zero cost

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/ActionBar.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/ActionBar.tsx
@@ -12,6 +12,7 @@ interface ActionBarProps {
   inputMode?: 'scan' | 'manual';
   paymentInputMode?: 'scan' | 'manual';
   hasSufficientQuota?: boolean;
+  swapCost?: number;
 }
 
 // Icon components for action bar
@@ -60,7 +61,7 @@ interface StepActionConfig {
   mainClass?: string;
 }
 
-const getStepConfig = (step: AttendantStep, inputMode?: 'scan' | 'manual', hasSufficientQuota?: boolean, paymentInputMode?: 'scan' | 'manual'): StepActionConfig => {
+const getStepConfig = (step: AttendantStep, inputMode?: 'scan' | 'manual', hasSufficientQuota?: boolean, paymentInputMode?: 'scan' | 'manual', swapCost?: number): StepActionConfig => {
   switch (step) {
     case 1:
       // Show different text/icon based on input mode
@@ -73,8 +74,11 @@ const getStepConfig = (step: AttendantStep, inputMode?: 'scan' | 'manual', hasSu
     case 3:
       return { showBack: true, mainTextKey: 'attendant.scanNewBattery', mainIcon: 'scan' };
     case 4:
-      // Show "Complete Swap" with check icon when customer has sufficient quota
-      if (hasSufficientQuota) {
+      // Show "Complete Swap" with check icon when:
+      // 1. Customer has sufficient quota, OR
+      // 2. Total cost is zero or negative (nothing to collect)
+      const shouldSkipPayment = hasSufficientQuota || (swapCost !== undefined && swapCost <= 0);
+      if (shouldSkipPayment) {
         return { showBack: true, mainTextKey: 'attendant.completeSwap', mainIcon: 'check', mainClass: 'btn-success' };
       }
       return { showBack: true, mainTextKey: 'attendant.collectPayment', mainIcon: 'arrow' };
@@ -92,9 +96,9 @@ const getStepConfig = (step: AttendantStep, inputMode?: 'scan' | 'manual', hasSu
   }
 };
 
-export default function ActionBar({ currentStep, onBack, onMainAction, isLoading, inputMode, paymentInputMode, hasSufficientQuota }: ActionBarProps) {
+export default function ActionBar({ currentStep, onBack, onMainAction, isLoading, inputMode, paymentInputMode, hasSufficientQuota, swapCost }: ActionBarProps) {
   const { t } = useI18n();
-  const config = getStepConfig(currentStep, inputMode, hasSufficientQuota, paymentInputMode);
+  const config = getStepConfig(currentStep, inputMode, hasSufficientQuota, paymentInputMode, swapCost);
 
   // Don't show the action bar button for step 1 in manual mode - button is in the form
   const hideMainButton = currentStep === 1 && inputMode === 'manual';

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -17,6 +17,12 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
   // Check if customer has partial quota (some quota but not enough to cover full energy diff)
   const hasPartialQuota = swapData.quotaDeduction > 0 && swapData.chargeableEnergy > 0;
   
+  // Check if cost is zero or negative (no payment needed regardless of quota status)
+  const isZeroCost = swapData.cost <= 0;
+  
+  // Should skip payment: either has sufficient quota OR cost is zero
+  const shouldSkipPayment = hasSufficientQuota || isZeroCost;
+  
   return (
     <div className="screen active">
       {/* Compact Header with Customer + Battery Summary */}
@@ -72,8 +78,8 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
         />
       </div>
 
-      {/* Quota Credit Banner - Shows when customer has sufficient quota (full coverage) */}
-      {hasSufficientQuota && (
+      {/* No Payment Banner - Shows when customer has sufficient quota OR cost is zero */}
+      {shouldSkipPayment && (
         <div className="quota-credit-banner" style={{ margin: '0 0 8px 0', padding: '10px 12px' }}>
           <div className="quota-credit-icon" style={{ width: '28px', height: '28px' }}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -82,8 +88,16 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
             </svg>
           </div>
           <div className="quota-credit-text">
-            <div className="quota-credit-title" style={{ fontSize: '13px' }}>{t('attendant.quotaCreditAvailable') || 'Quota Credit Available'}</div>
-            <div className="quota-credit-subtitle" style={{ fontSize: '11px' }}>{t('attendant.noPaymentRequired') || 'No payment required - using existing credit'}</div>
+            <div className="quota-credit-title" style={{ fontSize: '13px' }}>
+              {hasSufficientQuota 
+                ? (t('attendant.quotaCreditAvailable') || 'Quota Credit Available')
+                : (t('attendant.zeroCostSwap') || 'Zero Cost Swap')}
+            </div>
+            <div className="quota-credit-subtitle" style={{ fontSize: '11px' }}>
+              {hasSufficientQuota 
+                ? (t('attendant.noPaymentRequired') || 'No payment required - using existing credit')
+                : (t('attendant.noPaymentRequiredZeroCost') || 'No payment required - zero total cost')}
+            </div>
           </div>
         </div>
       )}
@@ -145,7 +159,7 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
         <div style={{ height: '1px', background: 'rgba(255,255,255,0.1)', margin: '8px 0' }} />
 
         {/* Total */}
-        <div className={`cost-total ${hasSufficientQuota ? 'cost-total-credit' : ''}`} style={{ padding: '6px 0' }}>
+        <div className={`cost-total ${shouldSkipPayment ? 'cost-total-credit' : ''}`} style={{ padding: '6px 0' }}>
           <span className="cost-total-label" style={{ fontSize: '13px' }}>
             {hasSufficientQuota 
               ? (t('attendant.quotaDeduction') || 'Quota Deduction') 

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1140,6 +1140,8 @@
   
   "attendant.quotaCreditAvailable": "Quota Credit Available",
   "attendant.noPaymentRequired": "No payment required - using existing credit",
+  "attendant.zeroCostSwap": "Zero Cost Swap",
+  "attendant.noPaymentRequiredZeroCost": "No payment required - zero total cost",
   "attendant.quotaDeduction": "Quota Deduction",
   "attendant.quotaApplied": "Quota Applied",
   "attendant.chargeableEnergy": "To Pay",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1131,6 +1131,8 @@
   
   "attendant.quotaCreditAvailable": "Crédit de quota disponible",
   "attendant.noPaymentRequired": "Aucun paiement requis - utilisation du crédit existant",
+  "attendant.zeroCostSwap": "Échange sans frais",
+  "attendant.noPaymentRequiredZeroCost": "Aucun paiement requis - coût total zéro",
   "attendant.quotaDeduction": "Déduction du quota",
   "attendant.quotaApplied": "Quota Appliqué",
   "attendant.chargeableEnergy": "À Payer",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1042,6 +1042,8 @@
   
   "attendant.quotaCreditAvailable": "可用配额余额",
   "attendant.noPaymentRequired": "无需支付 - 使用现有额度",
+  "attendant.zeroCostSwap": "零费用更换",
+  "attendant.noPaymentRequiredZeroCost": "无需支付 - 总费用为零",
   "attendant.quotaDeduction": "配额扣除",
   "attendant.quotaApplied": "已应用配额",
   "attendant.chargeableEnergy": "需支付",


### PR DESCRIPTION
Skip payment collection for zero-cost swaps to align with the no-payment flow for sufficient quota.

The previous logic for skipping payment (`hasSufficientQuota`) required both electricity and swap count quotas. This meant that if a swap had a zero cost (e.g., due to returned energy) but the user lacked a swap count quota, the system still prompted for payment. This PR ensures that if the calculated cost is zero or negative, the payment step is always skipped, regardless of quota status.

---
<a href="https://cursor.com/background-agent?bcId=bc-193df6ed-3349-4484-9ae7-fafb9957d448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-193df6ed-3349-4484-9ae7-fafb9957d448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

