### PR TITLE
Fix zero cost rounding payload

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -373,11 +373,13 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
     // === Check 1: Electricity Quota ===
     let hasEnoughElectricity = false;
     
-    // If rounded cost is 0 or negative, no electricity payment is needed
+    // If ACTUAL cost is 0 or negative, no electricity payment is needed
     // This handles cases where customer returns equal or more energy than they receive
-    // or when the calculated cost rounds down to 0 (e.g., 0.54 -> 0)
-    if (roundedCost <= 0) {
-      console.info('Electricity check: rounded cost is 0 or negative', { 
+    // NOTE: We use swapData.cost (not roundedCost) to distinguish between:
+    //   - True zero/negative cost (customer returning energy) → quota-based, no payment_data
+    //   - Zero-cost rounding (e.g., 0.54 → 0) → NOT quota-based, include payment_data with ZERO_COST_ROUNDING
+    if (swapData.cost <= 0) {
+      console.info('Electricity check: actual cost is 0 or negative (not zero-cost rounding)', { 
         cost: swapData.cost, 
         roundedCost 
       });


### PR DESCRIPTION
Correctly includes `payment_data` for zero-cost rounding cases by fixing the `hasSufficientQuota` calculation.

Previously, `hasSufficientQuota` was incorrectly set to `true` when `roundedCost <= 0`, even if the actual `swapData.cost` was positive (e.g., 0.54). This prevented `isZeroCostRounding` from being `true` and omitted `payment_data` from the report, which is incorrect for zero-cost rounding scenarios. The fix changes the check to `swapData.cost <= 0` to accurately differentiate between true quota usage and zero-cost rounding.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f9d6b76-0bab-4581-9060-be68697ec64b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f9d6b76-0bab-4581-9060-be68697ec64b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

