### PR TITLE
Filter device list for batteries

### DIFF
--- a/src/components/shared/BatteryInputSelector.tsx
+++ b/src/components/shared/BatteryInputSelector.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef } from 'react';
 import { useI18n } from '@/i18n';
 import { colors, spacing, radius, fontSize, fontWeight } from '@/styles';
-import BleDeviceList from './BleDeviceList';
+import BleDeviceList, { filterBatteryDevices } from './BleDeviceList';
 import type { BleDevice, BatteryData } from './types';
 
 /**
@@ -228,10 +228,11 @@ export default function BatteryInputSelector({
       )}
 
       {/* Device List - Always visible, no scrolling needed to discover */}
+      {/* Filter to show only battery devices (those with "BATT" or "Batt" in name) */}
       {!isFirstTimeCustomer && (
         <div className="battery-input-device-list">
           <BleDeviceList
-            devices={detectedDevices}
+            devices={filterBatteryDevices(detectedDevices)}
             selectedDevice={selectedDeviceMac}
             isScanning={isScanning}
             onSelectDevice={onDeviceSelect}

--- a/src/components/shared/BleDeviceList.tsx
+++ b/src/components/shared/BleDeviceList.tsx
@@ -59,6 +59,29 @@ interface BleDeviceListProps {
 }
 
 /**
+ * Check if a device is a battery based on its name
+ * Batteries have "BATT" or "Batt" as the second word in their name
+ * Example device names: "OVES BATT 45AH2311000102", "OVES Batt 45AH2311000103"
+ */
+export function isBatteryDevice(deviceName: string): boolean {
+  const nameParts = deviceName.split(' ');
+  if (nameParts.length >= 2) {
+    const deviceType = nameParts[1].toLowerCase();
+    return deviceType === 'batt';
+  }
+  return false;
+}
+
+/**
+ * Filter a list of BLE devices to only include batteries
+ * @param devices - Array of BLE devices to filter
+ * @returns Array of devices that are batteries
+ */
+export function filterBatteryDevices(devices: BleDevice[]): BleDevice[] {
+  return devices.filter(device => isBatteryDevice(device.name));
+}
+
+/**
  * Get device image URL based on device name
  * Returns null for unmapped devices (better to show nothing than confuse users)
  */

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -33,7 +33,7 @@ export type { BatteryScanMode } from './BatteryScanBind';
 // ============================================
 // BATTERY INPUT COMPONENTS (Scan & Manual Selection)
 // ============================================
-export { default as BleDeviceList } from './BleDeviceList';
+export { default as BleDeviceList, isBatteryDevice, filterBatteryDevices } from './BleDeviceList';
 export { default as BatteryInputSelector } from './BatteryInputSelector';
 export type { BatteryInputMode, BatteryOperationMode } from './BatteryInputSelector';
 


### PR DESCRIPTION
Filter the detected BLE device list in the Sales and Attendant workflows to show only battery devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a32f1c1-6a19-4a1c-b365-109ab5085038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a32f1c1-6a19-4a1c-b365-109ab5085038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

