### PR TITLE
Fix scanning icon animation

### DIFF
--- a/src/components/shared/BleDeviceList.tsx
+++ b/src/components/shared/BleDeviceList.tsx
@@ -242,7 +242,7 @@ export default function BleDeviceList({
             aria-label={isScanning ? (t('ble.stopScanning') || 'Stop scanning') : (t('ble.rescan') || 'Rescan')}
             title={isScanning ? (t('ble.tapToStop') || 'Tap to stop scanning') : (t('ble.tapToRescan') || 'Tap to rescan')}
           >
-            {isScanning ? <StopIcon /> : <RefreshIcon />}
+            <RefreshIcon />
           </button>
         )}
       </div>
@@ -728,23 +728,6 @@ function RefreshIcon() {
       <polyline points="23 4 23 10 17 10"/>
       <polyline points="1 20 1 14 7 14"/>
       <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
-    </svg>
-  );
-}
-
-function StopIcon() {
-  return (
-    <svg 
-      viewBox="0 0 24 24" 
-      fill="none" 
-      stroke="currentColor" 
-      strokeWidth="2" 
-      strokeLinecap="round" 
-      strokeLinejoin="round"
-      width="18"
-      height="18"
-    >
-      <rect x="6" y="6" width="12" height="12" rx="2" />
     </svg>
   );
 }


### PR DESCRIPTION
Maintain refresh icon for BLE scanning button, spinning when active.

Previously, the button displayed a spinning stop icon when scanning. This change ensures the refresh icon is always shown, with the existing CSS animation handling the spinning effect when scanning.

---
<a href="https://cursor.com/background-agent?bcId=bc-e04fae41-0dea-4b81-81e2-6d68d46934b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e04fae41-0dea-4b81-81e2-6d68d46934b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

