### PR TITLE
Fix energy rounding and device scan

### DIFF
--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -1343,7 +1343,9 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
     const correlationId = `sales-svc-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 
     // Calculate energy transferred in kWh (energy is stored in Wh)
-    const energyTransferred = scannedBatteryPending.energy / 1000;
+    // IMPORTANT: Round energy to 2 decimal places BEFORE using for calculations
+    // This ensures consistent values (e.g., 2.54530003 kWh becomes 2.54 kWh)
+    const energyTransferred = Math.floor((scannedBatteryPending.energy / 1000) * 100) / 100;
 
     // Use the FULL battery ID from QR scan - not truncated
     const fullBatteryId = scannedBatteryPending.id;

--- a/src/lib/hooks/ble/useBatteryScanAndBind.ts
+++ b/src/lib/hooks/ble/useBatteryScanAndBind.ts
@@ -186,10 +186,18 @@ export function useBatteryScanAndBind(options: UseBatteryScanAndBindOptions = {}
     // This ensures the progress modal stays visible during device discovery
     const shouldBeConnecting = connectionState.isConnecting || isDeviceMatchingRef.current;
 
+    // Filter out the connected device from the detected devices list
+    // This prevents showing a device we're already connected to when rescanning
+    const filteredDevices = connectionState.connectedDevice
+      ? scannerScanState.detectedDevices.filter(
+          device => device.macAddress.toUpperCase() !== connectionState.connectedDevice?.toUpperCase()
+        )
+      : scannerScanState.detectedDevices;
+
     setState(prev => ({
       ...prev,
       isScanning: scannerScanState.isScanning,
-      detectedDevices: scannerScanState.detectedDevices,
+      detectedDevices: filteredDevices,
       isConnecting: shouldBeConnecting,
       isConnected: connectionState.isConnected,
       connectedDevice: connectionState.connectedDevice,

--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -184,10 +184,18 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
       // This ensures the progress modal stays visible during device discovery
       const shouldBeConnecting = connectionState.isConnecting || isDeviceMatchingRef.current;
       
+      // Filter out the connected device from the detected devices list
+      // This prevents showing a device we're already connected to when rescanning
+      const filteredDevices = connectionState.connectedDevice
+        ? scannerScanState.detectedDevices.filter(
+            device => device.macAddress.toUpperCase() !== connectionState.connectedDevice?.toUpperCase()
+          )
+        : scannerScanState.detectedDevices;
+      
       return {
         ...prev,
         isScanning: scannerScanState.isScanning,
-        detectedDevices: scannerScanState.detectedDevices,
+        detectedDevices: filteredDevices,
         isConnecting: shouldBeConnecting,
         connectedDevice: connectionState.connectedDevice,
         connectionProgress: serviceState.isReading 


### PR DESCRIPTION
Round down energy transferred to two decimal places in Sales Workflow and filter out the connected device from BLE scan results during rescanning.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0e6d384-c120-4130-87ff-30dfc91c493b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d0e6d384-c120-4130-87ff-30dfc91c493b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

