### PR TITLE
Fix currency display issue

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -619,6 +619,7 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
                 const sourceData = isIdempotent ? metadata?.cached_result : metadata;
                 const servicePlanData = sourceData?.service_plan_data || sourceData?.servicePlanData;
                 const serviceBundle = sourceData?.service_bundle;
+                const commonTerms = sourceData?.common_terms;
                 const identifiedCustomerId = sourceData?.customer_id || metadata?.customer_id;
                 
                 if (servicePlanData) {
@@ -651,9 +652,15 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
                     (s: any) => s.service_id?.includes('service-swap-count')
                   );
                   
-                  if (elecService?.usageUnitPrice) {
-                    setSwapData(prev => ({ ...prev, rate: elecService.usageUnitPrice }));
-                  }
+                  // Extract billing currency from common_terms (source of truth), fallback to service plan currency
+                  const billingCurrency = commonTerms?.billingCurrency || servicePlanData?.currency || PAYMENT.defaultCurrency;
+                  
+                  // Update swap data with rate and currency from customer's service plan
+                  setSwapData(prev => ({ 
+                    ...prev, 
+                    rate: elecService?.usageUnitPrice || prev.rate,
+                    currencySymbol: billingCurrency 
+                  }));
                   
                   // Check for infinite quota services (quota > 100,000 indicates management services)
                   const INFINITE_QUOTA_THRESHOLD = 100000;
@@ -1411,6 +1418,7 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
                 const sourceData = isIdempotent ? metadata?.cached_result : metadata;
                 const servicePlanData = sourceData?.service_plan_data || sourceData?.servicePlanData;
                 const serviceBundle = sourceData?.service_bundle;
+                const commonTerms = sourceData?.common_terms;
                 const identifiedCustomerId = sourceData?.customer_id || metadata?.customer_id;
                 
                 if (servicePlanData) {
@@ -1443,9 +1451,15 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
                     (s: any) => s.service_id?.includes('service-swap-count')
                   );
                   
-                  if (elecService?.usageUnitPrice) {
-                    setSwapData(prev => ({ ...prev, rate: elecService.usageUnitPrice }));
-                  }
+                  // Extract billing currency from common_terms (source of truth), fallback to service plan currency
+                  const billingCurrency = commonTerms?.billingCurrency || servicePlanData?.currency || PAYMENT.defaultCurrency;
+                  
+                  // Update swap data with rate and currency from customer's service plan
+                  setSwapData(prev => ({ 
+                    ...prev, 
+                    rate: elecService?.usageUnitPrice || prev.rate,
+                    currencySymbol: billingCurrency 
+                  }));
                   
                   // Check for infinite quota services (quota > 100,000 indicates management services)
                   const INFINITE_QUOTA_THRESHOLD = 100000;


### PR DESCRIPTION
Update the displayed currency on the review page to use `common_terms.billingCurrency` from the customer identification response, fixing an issue where a default currency was always shown.

The `swapData.currencySymbol` was initialized with a default ('KES') and was not being updated from the customer's service plan data. The `common_terms.billingCurrency` field, which specifies the actual billing currency, was previously ignored during customer identification processing. This PR ensures the correct currency is extracted and displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-8bd1fc5a-29f8-4eeb-803b-a4a6229034e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8bd1fc5a-29f8-4eeb-803b-a4a6229034e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

