### PR TITLE
Fix review page price

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -35,7 +35,10 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
   // Calculate monetary values for battery capacities
   const oldBatteryValue = Math.round(oldBatteryKwh * swapData.rate);
   const newBatteryValue = Math.round(newBatteryKwh * swapData.rate);
-  const energyDiffValue = Math.round(swapData.energyDiff * swapData.rate);
+  // Use displayCost (the actual amount customer pays) to be consistent with the hero section
+  // Previously this was: Math.round(swapData.energyDiff * swapData.rate) which showed gross value
+  // before quota deduction, causing a mismatch with the hero section
+  const energyDiffValue = displayCost;
 
   // Currency symbol from backend
   const currency = swapData.currencySymbol;
@@ -129,7 +132,9 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
         </svg>
         <div className="energy-info">
           <span className="energy-value">+{swapData.energyDiff.toFixed(2)} kWh</span>
-          <span className="energy-money">{currency} {energyDiffValue}</span>
+          <span className={`energy-money ${shouldSkipPayment ? 'free' : ''}`}>
+            {shouldSkipPayment ? (t('common.free') || 'FREE') : `${currency} ${energyDiffValue}`}
+          </span>
         </div>
       </div>
 
@@ -346,6 +351,11 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
           background: var(--accent);
           color: var(--bg-primary);
           border-radius: 4px;
+        }
+
+        .energy-money.free {
+          background: #10b981;
+          color: white;
         }
 
         /* Summary */

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -161,7 +161,7 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
         {/* Partial quota note */}
         {hasPartialQuota && !shouldSkipPayment && (
           <div className="summary-note">
-            {t('attendant.chargeableEnergy') || 'To Pay'}: {swapData.chargeableEnergy.toFixed(2)} kWh = {currency} {Math.round(swapData.chargeableEnergy * swapData.rate)}
+            {t('attendant.chargeableEnergy') || 'To Pay'}: {swapData.chargeableEnergy.toFixed(2)} kWh = {currency} {displayCost}
           </div>
         )}
       </div>


### PR DESCRIPTION
Aligns all monetary displays on the Review page to consistently use the `displayCost` (rounded down net cost) to prevent discrepancies between sections.

Previously, the hero section rounded down the net cost (`Math.floor(swapData.cost)`), while the "Energy Gain" and "To Pay" summary sections either recalculated using gross energy (`Math.round(swapData.energyDiff * swapData.rate)`) or rounded the net chargeable energy to the nearest integer (`Math.round(swapData.chargeableEnergy * swapData.rate)`). This caused inconsistencies, e.g., hero showing "1" while other sections showed "2" for the same transaction. This PR ensures all customer-facing payment amounts consistently reflect the `displayCost` (always rounded down).

---
<a href="https://cursor.com/background-agent?bcId=bc-9093d3da-2a88-4d01-bf77-3586493774ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9093d3da-2a88-4d01-bf77-3586493774ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

