### PR TITLE
Fix review page calculation

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1199,6 +1199,11 @@
   "common.free": "FREE",
   "attendant.perKwh": "kWh",
   "attendant.afterQuota": "After quota applied",
+  "attendant.powerBeingSold": "Energy purchased",
+  "attendant.quotaYouHave": "Your quota",
+  "attendant.balance": "Balance",
+  "attendant.amountToPay": "Amount to pay",
+  "attendant.roundingNote": "Decimals rounded down",
 
   "sales.selectBatteryManually": "Select Battery",
   "sales.selectFromNearbyDevices": "Choose from nearby devices",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1190,6 +1190,11 @@
   "common.free": "GRATUIT",
   "attendant.perKwh": "kWh",
   "attendant.afterQuota": "Après application du quota",
+  "attendant.powerBeingSold": "Énergie achetée",
+  "attendant.quotaYouHave": "Votre quota",
+  "attendant.balance": "Solde",
+  "attendant.amountToPay": "Montant à payer",
+  "attendant.roundingNote": "Décimales arrondies vers le bas",
 
   "sales.selectBatteryManually": "Sélectionner la batterie",
   "sales.selectFromNearbyDevices": "Choisir parmi les appareils à proximité",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1101,6 +1101,11 @@
   "common.free": "免费",
   "attendant.perKwh": "kWh",
   "attendant.afterQuota": "应用配额后",
+  "attendant.powerBeingSold": "购买的能量",
+  "attendant.quotaYouHave": "您的配额",
+  "attendant.balance": "余额",
+  "attendant.amountToPay": "应付金额",
+  "attendant.roundingNote": "小数已向下取整",
 
   "sales.selectBatteryManually": "选择电池",
   "sales.selectFromNearbyDevices": "从附近设备中选择",


### PR DESCRIPTION
Fix incorrect cost display for power differential and enhance pricing summary with a detailed calculation breakdown to improve transparency.

The previous cost display for the power differential showed the final cost after quota deduction, not the gross value of the energy transferred. Additionally, the pricing summary lacked a clear explanation of how the final amount was calculated, leading to user confusion. This PR provides a step-by-step calculation, including gross energy cost, quota application, and a note on decimal rounding.

---
<a href="https://cursor.com/background-agent?bcId=bc-c37d5a2f-1b63-4e89-813e-dd8c1f418817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c37d5a2f-1b63-4e89-813e-dd8c1f418817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

