### PR TITLE
Round energy to two decimals

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -239,8 +239,8 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
         return {
           ...prev,
           newBattery: battery,
-          // Energy values floored to 2 decimal places for consistency with pricing
-          energyDiff: Math.floor(energyDiffKwh * 100) / 100,
+          // All values already floored to 2 decimal places above
+          energyDiff: energyDiffKwh,
           quotaDeduction: Math.floor(quotaDeduction * 100) / 100,
           chargeableEnergy: chargeableEnergyFloored,
           cost: cost > 0 ? cost : 0,

--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -220,10 +220,10 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
         const chargeableEnergyRaw = Math.max(0, energyDiffKwh - quotaDeduction);
         const chargeableEnergyFloored = Math.floor(chargeableEnergyRaw * 100) / 100;
         
-        // Cost based on floored chargeable energy
-        // IMPORTANT: Use Math.floor to round DOWN - ensures payment is never more than service value
-        // This guarantees the recorded payment amount matches the displayed/charged amount
-        const cost = Math.floor(chargeableEnergyFloored * rate * 100) / 100;
+        // Cost = floored energy × rate (exact multiplication, no flooring)
+        // This is the true value of the energy for accurate quota tracking
+        // Customer pays Math.floor(cost) - whole number rounded down
+        const cost = chargeableEnergyFloored * rate;
         
         console.info('Energy differential calculated:', {
           oldEnergyWh: oldEnergy,

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -133,7 +133,8 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
           <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
         </svg>
         <div className="energy-info">
-          <span className="energy-value">+{swapData.energyDiff.toFixed(2)} kWh</span>
+          {/* Round DOWN energy to 2 decimal places for consistent reporting */}
+          <span className="energy-value">+{(Math.floor(swapData.energyDiff * 100) / 100).toFixed(2)} kWh</span>
           <span className="energy-money">
             {currency} {grossEnergyDiffValue.toFixed(2)}
           </span>
@@ -152,7 +153,8 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
         <div className="summary-row calculation">
           <span className="calc-label">{t('attendant.powerBeingSold') || 'Energy purchased'}</span>
           <span className="calc-formula">
-            {swapData.energyDiff.toFixed(2)} × {swapData.rate} = <strong>{currency} {grossEnergyDiffValue.toFixed(2)}</strong>
+            {/* Round DOWN energy to 2 decimal places for consistent reporting */}
+            {(Math.floor(swapData.energyDiff * 100) / 100).toFixed(2)} × {swapData.rate} = <strong>{currency} {grossEnergyDiffValue.toFixed(2)}</strong>
           </span>
         </div>
 

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -133,8 +133,8 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
           <path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/>
         </svg>
         <div className="energy-info">
-          {/* Round DOWN energy to 2 decimal places for consistent reporting */}
-          <span className="energy-value">+{(Math.floor(swapData.energyDiff * 100) / 100).toFixed(2)} kWh</span>
+          {/* swapData.energyDiff is already floored to 2 decimals */}
+          <span className="energy-value">+{swapData.energyDiff.toFixed(2)} kWh</span>
           <span className="energy-money">
             {currency} {grossEnergyDiffValue.toFixed(2)}
           </span>
@@ -153,8 +153,8 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
         <div className="summary-row calculation">
           <span className="calc-label">{t('attendant.powerBeingSold') || 'Energy purchased'}</span>
           <span className="calc-formula">
-            {/* Round DOWN energy to 2 decimal places for consistent reporting */}
-            {(Math.floor(swapData.energyDiff * 100) / 100).toFixed(2)} × {swapData.rate} = <strong>{currency} {grossEnergyDiffValue.toFixed(2)}</strong>
+            {/* swapData.energyDiff is already floored to 2 decimals */}
+            {swapData.energyDiff.toFixed(2)} × {swapData.rate} = <strong>{currency} {grossEnergyDiffValue.toFixed(2)}</strong>
           </span>
         </div>
 

--- a/src/components/shared/SuccessReceipt.tsx
+++ b/src/components/shared/SuccessReceipt.tsx
@@ -181,8 +181,8 @@ export function buildSwapReceiptRows(
     },
     { 
       label: t('attendant.energy') || 'Energy', 
-      // Round DOWN to 2 decimal places (floor) for consistent energy reporting
-      value: `${(Math.floor(data.energyDiff * 100) / 100).toFixed(2)} kWh`,
+      // data.energyDiff is already floored to 2 decimals
+      value: `${data.energyDiff.toFixed(2)} kWh`,
       mono: true 
     },
     { 

--- a/src/components/shared/SuccessReceipt.tsx
+++ b/src/components/shared/SuccessReceipt.tsx
@@ -181,7 +181,8 @@ export function buildSwapReceiptRows(
     },
     { 
       label: t('attendant.energy') || 'Energy', 
-      value: `${data.energyDiff.toFixed(2)} kWh`,
+      // Round DOWN to 2 decimal places (floor) for consistent energy reporting
+      value: `${(Math.floor(data.energyDiff * 100) / 100).toFixed(2)} kWh`,
       mono: true 
     },
     { 


### PR DESCRIPTION
Round down energy values to two decimal places in the Attendant workflow for consistent reporting.

---
<a href="https://cursor.com/background-agent?bcId=bc-d526caf9-68eb-4654-a0b3-3047621add5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d526caf9-68eb-4654-a0b3-3047621add5c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

