### PR TITLE
Fix payment calculation discrepancy

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -211,10 +211,12 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
         const elecUsed = Number(electricityServiceRef.current?.used ?? 0);
         const remainingQuotaKwh = Math.max(0, elecQuota - elecUsed);
         
-        // Calculate quota deduction
-        const quotaDeduction = energyDiffKwh > 0 
+        // Calculate quota deduction - floor to 2 decimal places BEFORE using in calculations
+        // This ensures consistency between the stored value and its use in cost calculation
+        const quotaDeductionRaw = energyDiffKwh > 0 
           ? Math.min(remainingQuotaKwh, energyDiffKwh) 
           : 0;
+        const quotaDeduction = Math.floor(quotaDeductionRaw * 100) / 100;
         
         // Chargeable energy after quota - floor to 2 decimal places for consistency
         const chargeableEnergyRaw = Math.max(0, energyDiffKwh - quotaDeduction);
@@ -230,6 +232,7 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
           newEnergyWh: battery.energy,
           energyDiffKwh,
           remainingQuotaKwh,
+          quotaDeductionRaw,
           quotaDeduction,
           chargeableEnergy: chargeableEnergyFloored,
           ratePerKwh: rate,
@@ -241,7 +244,7 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
           newBattery: battery,
           // All values already floored to 2 decimal places above
           energyDiff: energyDiffKwh,
-          quotaDeduction: Math.floor(quotaDeduction * 100) / 100,
+          quotaDeduction: quotaDeduction,  // Already floored above
           chargeableEnergy: chargeableEnergyFloored,
           cost: cost > 0 ? cost : 0,
         };

--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -203,74 +203,76 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
       setSwapData(prev => {
         const oldEnergy = prev.oldBattery?.energy || 0;
         const energyDiffWh = battery.energy - oldEnergy;
-        // IMPORTANT: Round energy to 2 decimal places BEFORE using for calculations
-        // This ensures consistent pricing (e.g., 2.54530003 kWh becomes 2.54 kWh)
-        const energyDiffKwh = Math.floor((energyDiffWh / 1000) * 100) / 100;
+        
+        // === STEP 1: Power Differential (ONLY rounding point for energy) ===
+        // Round DOWN to 2dp - this is the single source of truth for energy
+        const powerDifferential = Math.floor((energyDiffWh / 1000) * 100) / 100;
         
         // Get rate from electricity service
         const rate = electricityServiceRef.current?.usageUnitPrice || prev.rate;
         
-        // Get remaining electricity quota
+        // === STEP 2: Available Quota (use as-is from backend - already 2dp) ===
         const elecQuota = Number(electricityServiceRef.current?.quota ?? 0);
         const elecUsed = Number(electricityServiceRef.current?.used ?? 0);
-        const remainingQuotaKwh = Math.max(0, elecQuota - elecUsed);
+        const availableQuota = Math.max(0, elecQuota - elecUsed);
         
-        // Calculate quota deduction - floor to 2 decimal places BEFORE using in calculations
-        // This ensures consistency between the stored value and its use in cost calculation
-        const quotaDeductionRaw = energyDiffKwh > 0 
-          ? Math.min(remainingQuotaKwh, energyDiffKwh) 
+        // Quota to apply: min of available quota and power differential
+        // Use as-is, no rounding (backend values are already 2dp)
+        const quotaToApply = powerDifferential > 0 
+          ? Math.min(availableQuota, powerDifferential) 
           : 0;
-        const quotaDeduction = Math.floor(quotaDeductionRaw * 100) / 100;
         
-        // Chargeable energy after quota - floor to 2 decimal places for consistency
-        // Energy is always rounded DOWN so we don't charge for more than transferred
-        const chargeableEnergyRaw = Math.max(0, energyDiffKwh - quotaDeduction);
-        const chargeableEnergyFloored = Math.floor(chargeableEnergyRaw * 100) / 100;
+        // === STEP 3: Actual Energy to Pay For (DON'T round) ===
+        const actualEnergyToPay = Math.max(0, powerDifferential - quotaToApply);
         
-        // === MONETARY VALUES (Single Source of Truth) ===
-        // These are calculated ONCE here and used everywhere - no recalculation!
+        // === STEP 4: Cost to Report ===
+        // If more than 2dp, round UP to nearest 2dp, otherwise use as-is
+        const costRaw = actualEnergyToPay * rate;
+        // Check if costRaw has more than 2 decimal places
+        const costRounded = Math.round(costRaw * 100) / 100;
+        const hasMoreThan2dp = Math.abs(costRaw - costRounded) > 0.0000001;
+        const costToReport = hasMoreThan2dp ? Math.ceil(costRaw * 100) / 100 : costRounded;
         
-        // Gross energy cost: energyDiff × rate, rounded UP to 2dp
-        const grossEnergyCostRaw = energyDiffKwh * rate;
-        const grossEnergyCost = Math.ceil(grossEnergyCostRaw * 100) / 100;
+        // === MONETARY VALUES FOR DISPLAY (Single Source of Truth) ===
+        // Gross energy cost: powerDifferential × rate (round UP if >2dp)
+        const grossCostRaw = powerDifferential * rate;
+        const grossCostRounded = Math.round(grossCostRaw * 100) / 100;
+        const grossHasMoreThan2dp = Math.abs(grossCostRaw - grossCostRounded) > 0.0000001;
+        const grossEnergyCost = grossHasMoreThan2dp ? Math.ceil(grossCostRaw * 100) / 100 : grossCostRounded;
         
-        // Quota credit value: quotaDeduction × rate, rounded DOWN to 2dp (conservative)
-        const quotaCreditValueRaw = quotaDeduction * rate;
-        const quotaCreditValue = Math.floor(quotaCreditValueRaw * 100) / 100;
-        
-        // Final cost = ceil(chargeableEnergy × rate) to 2dp
-        // This ensures we never report less payment than the energy actually costs
-        // Example: 19.6432 → 19.65 (not 19.64)
-        // Customer pays Math.floor(cost) - whole number rounded down for actual payment
-        const costRaw = chargeableEnergyFloored * rate;
-        const cost = Math.ceil(costRaw * 100) / 100;
+        // Quota credit value: quotaToApply × rate (use as-is, both inputs are 2dp max)
+        const quotaCreditValue = Math.round(quotaToApply * rate * 100) / 100;
         
         console.info('Energy & cost calculated (SINGLE SOURCE OF TRUTH):', {
-          // Energy values (all floored to 2dp)
+          // Step 1: Power differential (ONLY rounding - floor to 2dp)
           oldEnergyWh: oldEnergy,
           newEnergyWh: battery.energy,
-          energyDiffKwh,
-          remainingQuotaKwh,
-          quotaDeduction,
-          chargeableEnergy: chargeableEnergyFloored,
-          // Monetary values (grossEnergyCost & cost rounded UP, quotaCreditValue rounded DOWN)
+          powerDifferential,
+          // Step 2: Available quota (as-is from backend)
+          availableQuota,
+          quotaToApply,
+          // Step 3: Actual energy to pay (no rounding)
+          actualEnergyToPay,
+          // Step 4: Cost (round UP if >2dp)
           ratePerKwh: rate,
+          costRaw,
+          costToReport,
+          // Display values
           grossEnergyCost,
           quotaCreditValue,
-          cost,
         });
         
         return {
           ...prev,
           newBattery: battery,
-          // Energy values (all floored to 2dp)
-          energyDiff: energyDiffKwh,
-          quotaDeduction: quotaDeduction,
-          chargeableEnergy: chargeableEnergyFloored,
-          // Monetary values (single source of truth - no recalculation elsewhere!)
-          grossEnergyCost,
-          quotaCreditValue,
-          cost: cost > 0 ? cost : 0,
+          // Energy values
+          energyDiff: powerDifferential,        // Step 1: floored to 2dp
+          quotaDeduction: quotaToApply,         // Step 2: as-is (already 2dp)
+          chargeableEnergy: actualEnergyToPay,  // Step 3: no rounding
+          // Monetary values (single source of truth)
+          grossEnergyCost,                      // For display
+          quotaCreditValue,                     // For display
+          cost: costToReport > 0 ? costToReport : 0,  // Step 4: round UP if >2dp
         };
       });
       advanceToStep(4);

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -35,9 +35,9 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
   // === USE STORED VALUES - NO RECALCULATION ===
   // These values are calculated ONCE in AttendantFlow.tsx (single source of truth)
   // Using them directly ensures display matches what's reported to backend
-  const grossEnergyCost = swapData.grossEnergyCost;     // energyDiff × rate, rounded UP
-  const quotaCreditValue = swapData.quotaCreditValue;   // quotaDeduction × rate, rounded DOWN
-  const balanceAfterQuota = swapData.cost;              // Final cost (chargeableEnergy × rate, rounded UP)
+  const grossEnergyCost = swapData.grossEnergyCost;     // energyDiff × rate (round UP if >2dp)
+  const quotaCreditValue = swapData.quotaCreditValue;   // quotaDeduction × rate (as-is, inputs already 2dp)
+  const balanceAfterQuota = swapData.cost;              // chargeableEnergy × rate (round UP if >2dp)
 
   // Currency symbol from backend
   const currency = swapData.currencySymbol;

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -28,24 +28,16 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
   const oldLevel = swapData.oldBattery?.chargeLevel ?? 0;
   const newLevel = swapData.newBattery?.chargeLevel ?? 0;
   
-  // Calculate monetary values for battery capacities
+  // Calculate monetary values for battery capacities (display only)
   const oldBatteryValue = Math.round(oldBatteryKwh * swapData.rate);
   const newBatteryValue = Math.round(newBatteryKwh * swapData.rate);
   
-  // Gross cost of the power differential (before quota deduction)
-  // This is: energyDiff × rate, rounded UP to 2dp to ensure we show true cost
-  const grossEnergyDiffValueRaw = swapData.energyDiff * swapData.rate;
-  const grossEnergyDiffValue = Math.ceil(grossEnergyDiffValueRaw * 100) / 100;
-  
-  // Quota credit value (the monetary value of quota being applied)
-  // Rounded DOWN to 2dp since this is a deduction (be conservative with credits)
-  const quotaCreditValueRaw = swapData.quotaDeduction * swapData.rate;
-  const quotaCreditValue = Math.floor(quotaCreditValueRaw * 100) / 100;
-  
-  // Balance after quota - use swapData.cost directly since it's the correctly
-  // calculated value (energy floored, cost rounded UP to 2dp)
-  // This ensures display matches what's reported to backend
-  const balanceAfterQuota = swapData.cost;
+  // === USE STORED VALUES - NO RECALCULATION ===
+  // These values are calculated ONCE in AttendantFlow.tsx (single source of truth)
+  // Using them directly ensures display matches what's reported to backend
+  const grossEnergyCost = swapData.grossEnergyCost;     // energyDiff × rate, rounded UP
+  const quotaCreditValue = swapData.quotaCreditValue;   // quotaDeduction × rate, rounded DOWN
+  const balanceAfterQuota = swapData.cost;              // Final cost (chargeableEnergy × rate, rounded UP)
 
   // Currency symbol from backend
   const currency = swapData.currencySymbol;
@@ -141,7 +133,7 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
           {/* swapData.energyDiff is already floored to 2 decimals */}
           <span className="energy-value">+{swapData.energyDiff.toFixed(2)} kWh</span>
           <span className="energy-money">
-            {currency} {grossEnergyDiffValue.toFixed(2)}
+            {currency} {grossEnergyCost.toFixed(2)}
           </span>
         </div>
       </div>
@@ -158,8 +150,8 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
         <div className="summary-row calculation">
           <span className="calc-label">{t('attendant.powerBeingSold') || 'Energy purchased'}</span>
           <span className="calc-formula">
-            {/* swapData.energyDiff is already floored to 2 decimals */}
-            {swapData.energyDiff.toFixed(2)} × {swapData.rate} = <strong>{currency} {grossEnergyDiffValue.toFixed(2)}</strong>
+            {/* All values from swapData - single source of truth */}
+            {swapData.energyDiff.toFixed(2)} × {swapData.rate} = <strong>{currency} {grossEnergyCost.toFixed(2)}</strong>
           </span>
         </div>
 

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -33,14 +33,19 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
   const newBatteryValue = Math.round(newBatteryKwh * swapData.rate);
   
   // Gross cost of the power differential (before quota deduction)
-  // This is: energyDiff × rate - the raw value of the energy being transferred
-  const grossEnergyDiffValue = swapData.energyDiff * swapData.rate;
+  // This is: energyDiff × rate, rounded UP to 2dp to ensure we show true cost
+  const grossEnergyDiffValueRaw = swapData.energyDiff * swapData.rate;
+  const grossEnergyDiffValue = Math.ceil(grossEnergyDiffValueRaw * 100) / 100;
   
   // Quota credit value (the monetary value of quota being applied)
-  const quotaCreditValue = swapData.quotaDeduction * swapData.rate;
+  // Rounded DOWN to 2dp since this is a deduction (be conservative with credits)
+  const quotaCreditValueRaw = swapData.quotaDeduction * swapData.rate;
+  const quotaCreditValue = Math.floor(quotaCreditValueRaw * 100) / 100;
   
-  // Balance after quota (the raw balance before rounding)
-  const balanceAfterQuota = grossEnergyDiffValue - quotaCreditValue;
+  // Balance after quota - use swapData.cost directly since it's the correctly
+  // calculated value (energy floored, cost rounded UP to 2dp)
+  // This ensures display matches what's reported to backend
+  const balanceAfterQuota = swapData.cost;
 
   // Currency symbol from backend
   const currency = swapData.currencySymbol;

--- a/src/app/(mobile)/attendant/attendant/components/types.ts
+++ b/src/app/(mobile)/attendant/attendant/components/types.ts
@@ -79,12 +79,16 @@ export interface BleScanState {
 export interface SwapData {
   oldBattery: BatteryData | null;
   newBattery: BatteryData | null;
-  energyDiff: number;
-  quotaDeduction: number;  // Amount of remaining quota to apply (in kWh)
-  chargeableEnergy: number;  // Energy to charge for after quota deduction (in kWh)
-  cost: number;
+  // Energy values (all in kWh, floored to 2dp)
+  energyDiff: number;           // Total energy transferred (newBattery - oldBattery)
+  quotaDeduction: number;       // Amount of remaining quota to apply
+  chargeableEnergy: number;     // Energy to charge for after quota deduction
+  // Monetary values (calculated once, used everywhere - single source of truth)
+  grossEnergyCost: number;      // energyDiff × rate, rounded UP to 2dp
+  quotaCreditValue: number;     // quotaDeduction × rate, rounded DOWN to 2dp
+  cost: number;                 // Final cost = ceil(chargeableEnergy × rate) to 2dp
   rate: number;
-  currencySymbol: string;  // Currency from customer subscription or station config
+  currencySymbol: string;       // Currency from customer subscription or station config
 }
 
 export type AttendantStep = 1 | 2 | 3 | 4 | 5 | 6;

--- a/src/app/(mobile)/attendant/attendant/components/types.ts
+++ b/src/app/(mobile)/attendant/attendant/components/types.ts
@@ -79,16 +79,17 @@ export interface BleScanState {
 export interface SwapData {
   oldBattery: BatteryData | null;
   newBattery: BatteryData | null;
-  // Energy values (all in kWh, floored to 2dp)
-  energyDiff: number;           // Total energy transferred (newBattery - oldBattery)
-  quotaDeduction: number;       // Amount of remaining quota to apply
-  chargeableEnergy: number;     // Energy to charge for after quota deduction
-  // Monetary values (calculated once, used everywhere - single source of truth)
-  grossEnergyCost: number;      // energyDiff × rate, rounded UP to 2dp
-  quotaCreditValue: number;     // quotaDeduction × rate, rounded DOWN to 2dp
-  cost: number;                 // Final cost = ceil(chargeableEnergy × rate) to 2dp
+  // === ENERGY VALUES (kWh) - Calculated once, cascading down ===
+  energyDiff: number;           // Step 1: Power differential = floor(Bat-B - Bat-A) to 2dp (ONLY rounding point)
+  quotaDeduction: number;       // Step 2: Quota to apply = min(availableQuota, energyDiff) - use as-is
+  chargeableEnergy: number;     // Step 3: Actual energy to pay = (energyDiff - quotaDeduction) - NO rounding
+  // === MONETARY VALUES - Single source of truth ===
+  grossEnergyCost: number;      // energyDiff × rate (round UP if >2dp)
+  quotaCreditValue: number;     // quotaDeduction × rate (as-is, inputs already 2dp)
+  cost: number;                 // Step 4: Cost to report = chargeableEnergy × rate (round UP if >2dp)
+  // Customer pays: floor(cost) - done at display/payment time
   rate: number;
-  currencySymbol: string;       // Currency from customer subscription or station config
+  currencySymbol: string;
 }
 
 export type AttendantStep = 1 | 2 | 3 | 4 | 5 | 6;


### PR DESCRIPTION
Fix payment calculation and reporting to prevent insufficient payment errors by applying correct rounding rules for energy and cost.

The previous logic caused discrepancies where the reported payment amount was less than the required amount due to `quotaDeduction` being floored inconsistently and the final `cost` not being rounded up. This led to "Payment amount insufficient" errors from the backend. The changes ensure energy is consistently rounded down to 2dp and the final cost is rounded up to 2dp, aligning with the business rules to always cover the service consumption.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cabb864-ef22-4021-ba48-a2502ed88926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5cabb864-ef22-4021-ba48-a2502ed88926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

