### PR TITLE
Fix electricity display precision

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -44,6 +44,7 @@ import {
   type PaymentRequestData,
 } from '@/lib/odoo-api';
 import { PAYMENT } from '@/lib/constants';
+import { round } from '@/lib/utils';
 
 // Define WebViewJavascriptBridge type for window
 interface WebViewJavascriptBridge {
@@ -419,7 +420,8 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
     } else if (electricityService) {
       const elecQuota = Number(electricityService.quota ?? 0);
       const elecUsed = Number(electricityService.used ?? 0);
-      const remainingElecQuota = elecQuota - elecUsed;
+      // Round to 2 decimal places to avoid floating-point precision issues (e.g., 3.47 - 3.46 = 0.01, not 0.010000000000000231)
+      const remainingElecQuota = round(elecQuota - elecUsed, 2);
       const energyNeeded = swapData.energyDiff;
       
       hasEnoughElectricity = Number.isFinite(remainingElecQuota) && 
@@ -700,7 +702,8 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
                   const hasInfiniteSwapQuota = (swapCountService?.quota || 0) > INFINITE_QUOTA_THRESHOLD;
                   
                   // Calculate remaining quota values
-                  const energyRemaining = elecService ? (elecService.quota - elecService.used) : 0;
+                  // Round to 2 decimal places to avoid floating-point precision issues (e.g., 3.47 - 3.46 = 0.01, not 0.010000000000000231)
+                  const energyRemaining = elecService ? round(elecService.quota - elecService.used, 2) : 0;
                   const energyUnitPrice = elecService?.usageUnitPrice || 0;
                   // Calculate monetary value of remaining energy quota (remaining kWh × unit price)
                   const energyValue = energyRemaining * energyUnitPrice;
@@ -1499,7 +1502,8 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
                   const hasInfiniteSwapQuota = (swapCountService?.quota || 0) > INFINITE_QUOTA_THRESHOLD;
                   
                   // Calculate remaining quota values
-                  const energyRemaining = elecService ? (elecService.quota - elecService.used) : 0;
+                  // Round to 2 decimal places to avoid floating-point precision issues (e.g., 3.47 - 3.46 = 0.01, not 0.010000000000000231)
+                  const energyRemaining = elecService ? round(elecService.quota - elecService.used, 2) : 0;
                   const energyUnitPrice = elecService?.usageUnitPrice || 0;
                   // Calculate monetary value of remaining energy quota (remaining kWh × unit price)
                   const energyValue = energyRemaining * energyUnitPrice;

--- a/src/app/(mobile)/attendant/attendant/swap.tsx
+++ b/src/app/(mobile)/attendant/attendant/swap.tsx
@@ -16,6 +16,7 @@ import { useBridge } from "@/app/context/bridgeContext";
 import { useI18n } from "@/i18n";
 import { initServiceBleData } from "@/app/utils";
 import { MqttReconnectBanner } from "@/components/shared";
+import { round } from "@/lib/utils";
 
 // ABS topics use hardcoded payloads as per docs; publish via bridge like BLE page..
 // PLAN_ID is now dynamically set from subscription_code in scanned QR code
@@ -3062,7 +3063,8 @@ const deriveCustomerTypeFromPayload = (payload?: any) => {
                             .filter((service) => service.quota <= 100000) // Filter out infinite quota management services
                             .map((service, index) => {
                               // Calculate remaining quota and its value
-                              const remaining = service.quota - service.used;
+                              // Round to 2 decimal places to avoid floating-point precision issues (e.g., 3.47 - 3.46 = 0.01, not 0.010000000000000231)
+                              const remaining = round(service.quota - service.used, 2);
                               const quotaValue = service.usageUnitPrice !== undefined 
                                 ? remaining * service.usageUnitPrice 
                                 : undefined;

--- a/src/components/ui/Progress.tsx
+++ b/src/components/ui/Progress.tsx
@@ -122,6 +122,28 @@ interface QuotaBarProps {
 }
 
 /**
+ * Round to specified decimal places to avoid floating-point precision issues
+ * (e.g., 3.47 - 3.46 = 0.01, not 0.010000000000000231)
+ */
+function roundValue(value: number, decimals: number = 2): number {
+  return Math.round(value * Math.pow(10, decimals)) / Math.pow(10, decimals);
+}
+
+/**
+ * Format remaining value for display, handling floating-point precision
+ */
+function formatRemaining(value: number): string {
+  // Round to 2 decimal places to avoid floating-point precision display issues
+  const rounded = roundValue(value, 2);
+  // If the rounded value is an integer, display without decimals
+  if (Number.isInteger(rounded)) {
+    return rounded.toString();
+  }
+  // Otherwise display with up to 2 decimal places, trimming trailing zeros
+  return rounded.toFixed(2).replace(/\.?0+$/, '');
+}
+
+/**
  * QuotaBar - Display remaining quota with visual bar
  */
 export function QuotaBar({
@@ -134,7 +156,9 @@ export function QuotaBar({
   currency = 'XOF',
   className = '',
 }: QuotaBarProps) {
-  const percent = total > 0 ? (remaining / total) * 100 : 0;
+  // Round values to avoid floating-point precision issues
+  const roundedRemaining = roundValue(remaining, 2);
+  const percent = total > 0 ? (roundedRemaining / total) * 100 : 0;
   const variant = getProgressColor(percent);
 
   // Default icons based on type
@@ -185,7 +209,7 @@ export function QuotaBar({
             fontWeight: 'var(--weight-semibold)',
             fontFamily: 'var(--font-mono)',
           }}>
-            {remaining}
+            {formatRemaining(remaining)}
           </span>
           <span style={{ 
             fontSize: 'var(--font-xs)', 
@@ -204,7 +228,7 @@ export function QuotaBar({
           )}
         </div>
         <ProgressBar 
-          value={remaining} 
+          value={roundedRemaining} 
           max={total} 
           variant={variant}
           height={6}


### PR DESCRIPTION
Fixes floating-point precision errors in quota calculations and display across the Attendant workflow.

Floating-point arithmetic (IEEE 754) can lead to inaccuracies where `3.47 - 3.46` results in `0.010000000000000231` instead of `0.01`. This PR applies a rounding utility to ensure calculations and displayed values are precise and human-readable.

---
<a href="https://cursor.com/background-agent?bcId=bc-0eb6aacd-a7fb-43d2-99f3-4712cd1c767c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0eb6aacd-a7fb-43d2-99f3-4712cd1c767c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

