### PR TITLE
Update device id usage

### DIFF
--- a/src/components/shared/BatteryCard.tsx
+++ b/src/components/shared/BatteryCard.tsx
@@ -71,6 +71,9 @@ export default function BatteryCard({
   }
 
   // Compact variant
+  // Use actualBatteryId (OPID/PPID from ATT service) as primary display
+  const displayId = battery.actualBatteryId || battery.shortId || '---';
+  
   return (
     <div className={`battery-return-card ${className}`}>
       <div className="battery-return-header">
@@ -82,7 +85,7 @@ export default function BatteryCard({
         )}
       </div>
       <div className="battery-return-content">
-        <div className="battery-return-id">{battery.shortId || '---'}</div>
+        <div className="battery-return-id">{displayId}</div>
         <div className="battery-return-charge">
           <div className={`battery-return-icon ${batteryClass}`}>
             <div 
@@ -121,6 +124,9 @@ function BatteryDetailedCard({
   const chargeLevel = battery.chargeLevel ?? 0;
   const energyKwh = battery.energy / 1000;
   const batteryClass = getBatteryClass(chargeLevel);
+  
+  // Use actualBatteryId (OPID/PPID from ATT service) as primary display
+  const displayId = battery.actualBatteryId || battery.shortId;
 
   return (
     <div className={`battery-scanned-card ${className}`} style={{ marginBottom: '20px' }}>
@@ -131,7 +137,7 @@ function BatteryDetailedCard({
             {title || t('sales.newBattery')}
           </div>
           <div className="font-mono-oves" style={{ fontSize: '16px', fontWeight: 600 }}>
-            {battery.shortId}
+            {displayId}
           </div>
         </div>
         {isConnected && (
@@ -229,6 +235,7 @@ interface BatterySwapVisualProps {
 
 /**
  * BatterySwapVisual - Shows side-by-side comparison of old and new batteries
+ * Uses actualBatteryId (OPID/PPID from ATT service) as the primary display ID
  */
 export function BatterySwapVisual({
   oldBattery,
@@ -239,6 +246,10 @@ export function BatterySwapVisual({
   const newLevel = newBattery?.chargeLevel ?? 0;
   const oldEnergyKwh = (oldBattery?.energy ?? 0) / 1000;
   const newEnergyKwh = (newBattery?.energy ?? 0) / 1000;
+  
+  // Use actualBatteryId (OPID/PPID from ATT service) as primary display
+  const oldDisplayId = oldBattery?.actualBatteryId || oldBattery?.shortId || '---';
+  const newDisplayId = newBattery?.actualBatteryId || newBattery?.shortId || '---';
 
   return (
     <div className={`battery-swap-visual ${className}`}>
@@ -252,7 +263,7 @@ export function BatterySwapVisual({
           <span className="battery-percent">{oldEnergyKwh.toFixed(2)} kWh</span>
         </div>
         <div className="battery-swap-label">RETURNING</div>
-        <div className="battery-swap-id">{oldBattery?.shortId || '---'}</div>
+        <div className="battery-swap-id">{oldDisplayId}</div>
       </div>
       
       {/* Arrow */}
@@ -272,7 +283,7 @@ export function BatterySwapVisual({
           <span className="battery-percent">{newEnergyKwh.toFixed(2)} kWh</span>
         </div>
         <div className="battery-swap-label">RECEIVING</div>
-        <div className="battery-swap-id">{newBattery?.shortId || '---'}</div>
+        <div className="battery-swap-id">{newDisplayId}</div>
       </div>
     </div>
   );

--- a/src/components/shared/BatteryInputSelector.tsx
+++ b/src/components/shared/BatteryInputSelector.tsx
@@ -190,6 +190,7 @@ export default function BatteryInputSelector({
       </div>
 
       {/* Previous Battery Card (issue mode) - Compact */}
+      {/* Uses actualBatteryId (OPID/PPID from ATT service) as the primary display ID */}
       {mode === 'issue' && previousBattery && (
         <div className="battery-return-card">
           <div className="battery-return-header">
@@ -197,7 +198,9 @@ export default function BatteryInputSelector({
             <span className="battery-return-status">✓ {t('common.connected') || 'Connected'}</span>
           </div>
           <div className="battery-return-content">
-            <div className="battery-return-id">{previousBattery.shortId || previousBattery.id}</div>
+            <div className="battery-return-id">
+              {previousBattery.actualBatteryId || previousBattery.shortId || previousBattery.id}
+            </div>
             <div className="battery-return-energy">
               {(previousBattery.energy / 1000).toFixed(3)} kWh {t('attendant.remaining') || 'remaining'}
             </div>

--- a/src/components/shared/BatteryScanBind.tsx
+++ b/src/components/shared/BatteryScanBind.tsx
@@ -383,12 +383,17 @@ function getBatteryClass(level: number): 'full' | 'medium' | 'low' {
 
 /**
  * Shows the returned battery card (used in issue mode)
+ * Uses actualBatteryId (OPID/PPID from ATT service) as the primary display ID
  */
 function BatteryReturnCard({ battery }: { battery: BatteryData }) {
   const { t } = useI18n();
   const chargeLevel = battery.chargeLevel ?? 0;
   const energyKwh = battery.energy / 1000;
   const batteryClass = getBatteryClass(chargeLevel);
+
+  // Use actualBatteryId (OPID/PPID from ATT service) as primary display
+  // Falls back to shortId or id if actualBatteryId is not available
+  const displayId = battery.actualBatteryId || battery.shortId || battery.id || '---';
 
   return (
     <div className="battery-return-card">
@@ -397,7 +402,7 @@ function BatteryReturnCard({ battery }: { battery: BatteryData }) {
         <span className="battery-return-status">✓ {t('common.connected') || 'Connected'}</span>
       </div>
       <div className="battery-return-content">
-        <div className="battery-return-id">{battery.shortId || battery.id || '---'}</div>
+        <div className="battery-return-id">{displayId}</div>
         <div className="battery-return-charge">
           <div className={`battery-return-icon ${batteryClass}`}>
             <div 
@@ -427,6 +432,7 @@ const WAITING_TIPS = [
 const COUNTDOWN_START_SECONDS = 60;
 
 // Phase-specific messages for better feedback
+// User-friendly labels: "ID" for ATT service, "Energy" for DTA service
 const PHASE_MESSAGES = {
   scanning: {
     title: 'Searching for Device',
@@ -441,12 +447,12 @@ const PHASE_MESSAGES = {
     subtitle: 'Loading device information...',
   },
   readingDta: {
-    title: 'Reading DTA Service',
+    title: 'Reading Energy Data',
     subtitle: 'Getting energy data from battery...',
   },
   readingAtt: {
-    title: 'Reading ATT Service',
-    subtitle: 'Getting battery ID (opid/ppid)...',
+    title: 'Reading Battery ID',
+    subtitle: 'Getting battery identifier...',
   },
 };
 

--- a/src/components/shared/BleProgressModal.tsx
+++ b/src/components/shared/BleProgressModal.tsx
@@ -97,13 +97,13 @@ export function BleProgressModal({
     if (bleScanState.error) {
       return bleScanState.error;
     }
-    // Show specific messages for DTA → ATT reading phases
+    // Show specific messages for ATT → DTA reading phases (user-friendly labels)
     if (bleScanState.isReadingEnergy || bleScanState.isReadingService) {
       if (bleScanState.readingPhase === 'att') {
-        return 'Reading ATT service for battery ID...';
+        return 'Reading battery ID...';
       }
       if (bleScanState.readingPhase === 'dta') {
-        return 'Reading DTA service for energy data...';
+        return 'Reading energy data...';
       }
       return 'Reading battery data...';
     }
@@ -153,9 +153,9 @@ export function BleProgressModal({
                     ? 'Bluetooth Reset Required'
                     : (bleScanState.isReadingEnergy || bleScanState.isReadingService)
                     ? (bleScanState.readingPhase === 'att' 
-                        ? 'Reading ATT Service' 
+                        ? 'Reading Battery ID' 
                         : bleScanState.readingPhase === 'dta'
-                        ? 'Reading DTA Service'
+                        ? 'Reading Energy Data'
                         : 'Reading Battery Data')
                     : 'Connecting to Battery'}
             </div>
@@ -238,7 +238,8 @@ export function BleProgressModal({
           </div>
 
           {/* Step Indicators - Hide when Bluetooth reset is required */}
-          {/* Shows 4 steps: Scan → Connect → DTA (Energy) → ATT (Battery ID) */}
+          {/* Shows 4 steps: Scan → Connect → ID (ATT) → Energy (DTA) */}
+          {/* User-friendly labels: "ID" for ATT service, "Energy" for DTA service */}
           {!bleScanState.requiresBluetoothReset && (
             <div className="ble-progress-steps">
               <div className="ble-step active completed">
@@ -249,13 +250,13 @@ export function BleProgressModal({
                 <div className="ble-step-dot" />
                 <span>Connect</span>
               </div>
-              <div className={`ble-step ${(bleScanState.isReadingEnergy || bleScanState.isReadingService) && bleScanState.readingPhase !== 'idle' ? 'active' : ''} ${bleScanState.readingPhase === 'att' ? 'completed' : ''}`}>
+              <div className={`ble-step ${(bleScanState.isReadingEnergy || bleScanState.isReadingService) && bleScanState.readingPhase !== 'idle' ? 'active' : ''} ${bleScanState.readingPhase === 'dta' ? 'completed' : ''}`}>
                 <div className="ble-step-dot" />
-                <span>DTA</span>
+                <span>ID</span>
               </div>
-              <div className={`ble-step ${bleScanState.readingPhase === 'att' ? 'active' : ''}`}>
+              <div className={`ble-step ${bleScanState.readingPhase === 'dta' ? 'active' : ''}`}>
                 <div className="ble-step-dot" />
-                <span>ATT</span>
+                <span>Energy</span>
               </div>
             </div>
           )}

--- a/src/components/shared/types.ts
+++ b/src/components/shared/types.ts
@@ -13,6 +13,8 @@ export interface BatteryData {
   chargeLevel: number; // Charge percentage (0-100)
   energy: number; // Remaining energy in Wh
   macAddress?: string; // BLE MAC address used for connection
+  /** Actual battery ID from ATT service (OPID/PPID) - used for display and validation */
+  actualBatteryId?: string;
 }
 
 // BLE Device interface for scan-to-bind functionality

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1244,10 +1244,10 @@
   "ble.phase.connecting.subtitle": "Establishing Bluetooth connection...",
   "ble.phase.reading.title": "Reading Battery Data",
   "ble.phase.reading.subtitle": "Loading device information...",
-  "ble.phase.readingDta.title": "Reading DTA Service",
+  "ble.phase.readingDta.title": "Reading Energy Data",
   "ble.phase.readingDta.subtitle": "Getting energy data from battery...",
-  "ble.phase.readingAtt.title": "Reading ATT Service",
-  "ble.phase.readingAtt.subtitle": "Getting battery ID (opid/ppid)...",
+  "ble.phase.readingAtt.title": "Reading Battery ID",
+  "ble.phase.readingAtt.subtitle": "Getting battery identifier...",
   
   "rider.phoneNumber": "Phone Number",
   "rider.enterPhone": "Enter your phone number",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1235,10 +1235,10 @@
   "ble.phase.connecting.subtitle": "Établissement de la connexion Bluetooth...",
   "ble.phase.reading.title": "Lecture des données",
   "ble.phase.reading.subtitle": "Chargement des informations de l'appareil...",
-  "ble.phase.readingDta.title": "Lecture Service DTA",
+  "ble.phase.readingDta.title": "Lecture Données Énergie",
   "ble.phase.readingDta.subtitle": "Obtention des données d'énergie de la batterie...",
-  "ble.phase.readingAtt.title": "Lecture Service ATT",
-  "ble.phase.readingAtt.subtitle": "Obtention de l'ID batterie (opid/ppid)...",
+  "ble.phase.readingAtt.title": "Lecture ID Batterie",
+  "ble.phase.readingAtt.subtitle": "Obtention de l'identifiant de la batterie...",
   
   "rider.phoneNumber": "Numéro de téléphone",
   "rider.enterPhone": "Entrez votre numéro de téléphone",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1146,10 +1146,10 @@
   "ble.phase.connecting.subtitle": "正在建立蓝牙连接...",
   "ble.phase.reading.title": "读取电池数据",
   "ble.phase.reading.subtitle": "正在加载设备信息...",
-  "ble.phase.readingDta.title": "读取DTA服务",
+  "ble.phase.readingDta.title": "读取能量数据",
   "ble.phase.readingDta.subtitle": "正在获取电池能量数据...",
-  "ble.phase.readingAtt.title": "读取ATT服务",
-  "ble.phase.readingAtt.subtitle": "正在获取电池ID (opid/ppid)...",
+  "ble.phase.readingAtt.title": "读取电池ID",
+  "ble.phase.readingAtt.subtitle": "正在获取电池标识...",
   
   "rider.phoneNumber": "电话号码",
   "rider.enterPhone": "输入您的电话号码",


### PR DESCRIPTION
Improve BLE battery workflow by displaying actual OPID/PPID, adding a final ID validation step, and enhancing progress modal clarity.

The "last line of defense" validation ensures the actual battery ID read via BLE (OPID/PPID) matches the customer's assigned battery, preventing incorrect battery swaps even if initial device name checks pass.

---
<a href="https://cursor.com/background-agent?bcId=bc-f76bebf8-fc2e-4a49-947f-3408455a81ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f76bebf8-fc2e-4a49-947f-3408455a81ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

