### PR TITLE
Fix ble data reading flow

### DIFF
--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -205,6 +205,14 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
           )
         : scannerScanState.detectedDevices;
       
+      // CRITICAL FIX: Keep isReadingEnergy=true during ATT→DTA transition
+      // The service reader sets isReading=false when ATT completes, but we need to keep
+      // the modal visible while we transition to DTA reading.
+      // Use readingPhase !== 'idle' to ensure we stay in "reading" state during the full ATT→DTA flow.
+      // This prevents the BleProgressModal from closing prematurely between phases.
+      const isInReadingFlow = readingPhase !== 'idle';
+      const shouldBeReading = serviceState.isReading || isInReadingFlow;
+      
       return {
         ...prev,
         isScanning: scannerScanState.isScanning,
@@ -216,8 +224,8 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
           : connectionState.connectionProgress,
         connectionFailed: connectionState.connectionFailed,
         requiresBluetoothReset: connectionState.requiresBluetoothReset,
-        isReadingEnergy: serviceState.isReading,
-        isReadingService: serviceState.isReading,
+        isReadingEnergy: shouldBeReading,
+        isReadingService: shouldBeReading,
         readingPhase,
         error: scannerScanState.error || 
                connectionState.error || 


### PR DESCRIPTION
Fixes premature BLE Progress Modal closure and ensures correct ATT then DTA service reading order to prevent workflow failures.

The BLE Progress Modal was closing prematurely due to a race condition where `isReading` was set to `false` after the ATT service read completed, causing the UI to disappear before the DTA service read could begin. This PR also corrects the service read order in `useBatteryScanAndBind` from DTA→ATT to ATT→DTA, aligning it with `useFlowBatteryScan` for proper battery ID and energy data acquisition. Additionally, service data validation was added to prevent processing stale data during phase transitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb9d4909-2bfb-422a-9b93-5b307dd49fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb9d4909-2bfb-422a-9b93-5b307dd49fb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

