### PR TITLE
Fix ble connection stall

### DIFF
--- a/src/lib/hooks/ble/useBatteryScanAndBind.ts
+++ b/src/lib/hooks/ble/useBatteryScanAndBind.ts
@@ -280,7 +280,8 @@ export function useBatteryScanAndBind(options: UseBatteryScanAndBindOptions = {}
       // Check which phase we're in
       if (readingPhase === 'att') {
         // Verify this is actually ATT data (not stale DTA data)
-        if (serviceName && serviceName !== 'ATT') {
+        // serviceNameEnum from native layer is 'ATT_SERVICE', not just 'ATT'
+        if (serviceName && !serviceName.includes('ATT')) {
           log('Received non-ATT data while in ATT phase, ignoring:', serviceName);
           return;
         }
@@ -307,7 +308,8 @@ export function useBatteryScanAndBind(options: UseBatteryScanAndBindOptions = {}
         
       } else if (readingPhase === 'dta') {
         // Verify this is actually DTA data (not stale ATT data)
-        if (serviceName && serviceName !== 'DTA') {
+        // serviceNameEnum from native layer is 'DTA_SERVICE', not just 'DTA'
+        if (serviceName && !serviceName.includes('DTA')) {
           log('Received non-DTA data while in DTA phase, ignoring:', serviceName);
           return;
         }

--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -286,7 +286,8 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
       // Check which phase we're in
       if (readingPhase === 'att') {
         // Verify this is actually ATT data (not stale DTA data from a previous read)
-        if (serviceName && serviceName !== 'ATT') {
+        // serviceNameEnum from native layer is 'ATT_SERVICE', not just 'ATT'
+        if (serviceName && !serviceName.includes('ATT')) {
           log('Received non-ATT data while in ATT phase, ignoring:', serviceName);
           return;
         }
@@ -313,7 +314,8 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
         
       } else if (readingPhase === 'dta') {
         // Verify this is actually DTA data (not stale ATT data)
-        if (serviceName && serviceName !== 'DTA') {
+        // serviceNameEnum from native layer is 'DTA_SERVICE', not just 'DTA'
+        if (serviceName && !serviceName.includes('DTA')) {
           log('Received non-DTA data while in DTA phase, ignoring:', serviceName);
           return;
         }


### PR DESCRIPTION
Fixes BLE flow stalling after ATT data read by correcting service name comparison for ATT and DTA services.

The BLE process for reading ATT (Battery ID) and DTA (Power Metrics) was getting stuck because the `serviceName` comparison was using an exact match (`'ATT'` or `'DTA'`) instead of checking for inclusion. The native BLE layer returns service names like `'ATT_SERVICE'` and `'DTA_SERVICE'`, which caused the data to be incorrectly ignored. This PR updates the comparison to use `includes()` to correctly identify and process the service data.

---
<a href="https://cursor.com/background-agent?bcId=bc-938c25ae-ff35-4c4f-a549-f6fd3d7ef889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-938c25ae-ff35-4c4f-a549-f6fd3d7ef889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

