### PR TITLE
Fix receipt battery id

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/BatterySwapVisual.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/BatterySwapVisual.tsx
@@ -29,7 +29,7 @@ export default function BatterySwapVisual({ oldBattery, newBattery }: BatterySwa
           <span className="battery-percent">{oldEnergyKwh.toFixed(2)} kWh</span>
         </div>
         <div className="battery-swap-label">RETURNING</div>
-        <div className="battery-swap-id">{oldBattery?.shortId || '---'}</div>
+        <div className="battery-swap-id">{oldBattery?.actualBatteryId || oldBattery?.shortId || '---'}</div>
       </div>
       
       {/* Arrow */}
@@ -49,7 +49,7 @@ export default function BatterySwapVisual({ oldBattery, newBattery }: BatterySwa
           <span className="battery-percent">{newEnergyKwh.toFixed(2)} kWh</span>
         </div>
         <div className="battery-swap-label">RECEIVING</div>
-        <div className="battery-swap-id">{newBattery?.shortId || '---'}</div>
+        <div className="battery-swap-id">{newBattery?.actualBatteryId || newBattery?.shortId || '---'}</div>
       </div>
     </div>
   );

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -93,7 +93,7 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
           <div className="battery-details">
             <span className="battery-energy">{oldBatteryKwh.toFixed(2)} kWh</span>
             <span className="battery-value">{currency} {oldBatteryValue}</span>
-            <span className="battery-id">{swapData.oldBattery?.shortId || '---'}</span>
+            <span className="battery-id">{swapData.oldBattery?.actualBatteryId || swapData.oldBattery?.shortId || '---'}</span>
           </div>
         </div>
         
@@ -119,7 +119,7 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
           <div className="battery-details">
             <span className="battery-energy">{newBatteryKwh.toFixed(2)} kWh</span>
             <span className="battery-value">{currency} {newBatteryValue}</span>
-            <span className="battery-id">{swapData.newBattery?.shortId || '---'}</span>
+            <span className="battery-id">{swapData.newBattery?.actualBatteryId || swapData.newBattery?.shortId || '---'}</span>
           </div>
         </div>
       </div>

--- a/src/app/(mobile)/attendant/attendant/components/steps/Step6Success.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step6Success.tsx
@@ -32,9 +32,11 @@ export default function Step6Success({
   const receiptRows = buildSwapReceiptRows({
     transactionId,
     customerName: customerData?.name || 'Customer',
-    oldBatteryId: swapData.oldBattery?.shortId || '---',
+    // Use actualBatteryId from ATT service (OPID/PPID), fallback to shortId (BLE device name)
+    oldBatteryId: swapData.oldBattery?.actualBatteryId || swapData.oldBattery?.shortId || '---',
     oldBatteryLevel: swapData.oldBattery?.chargeLevel ?? 0,
-    newBatteryId: swapData.newBattery?.shortId || '---',
+    // Use actualBatteryId from ATT service (OPID/PPID), fallback to shortId (BLE device name)
+    newBatteryId: swapData.newBattery?.actualBatteryId || swapData.newBattery?.shortId || '---',
     newBatteryLevel: swapData.newBattery?.chargeLevel ?? 0,
     energyDiff: swapData.energyDiff,
     amountDue,
@@ -46,7 +48,7 @@ export default function Step6Success({
     <div className="screen active">
       <SuccessReceipt
         title={t('attendant.swapComplete')}
-        message={t('attendant.handOverBattery') || `Hand over ${swapData.newBattery?.shortId || 'battery'} to customer`}
+        message={t('attendant.handOverBattery') || `Hand over ${swapData.newBattery?.actualBatteryId || swapData.newBattery?.shortId || 'battery'} to customer`}
         receiptId={transactionId}
         receiptTitle={t('attendant.transactionReceipt') || 'Transaction Receipt'}
         rows={receiptRows}

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -216,7 +216,8 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
       // User must click "Complete Service" to finalize the assignment
       console.info('Battery read via hook (for assignment):', battery);
       setScannedBatteryPending(battery);
-      toast.success(`Battery ${battery.shortId || battery.id} scanned! Click "Complete Service" to finalize.`);
+      // Use actualBatteryId from ATT service (OPID/PPID), fallback to shortId or id
+      toast.success(`Battery ${battery.actualBatteryId || battery.shortId || battery.id} scanned! Click "Complete Service" to finalize.`);
       setIsScannerOpening(false);
       scanTypeRef.current = null;
     },

--- a/src/app/(mobile)/customers/customerform/components/steps/Step5Success.tsx
+++ b/src/app/(mobile)/customers/customerform/components/steps/Step5Success.tsx
@@ -51,7 +51,8 @@ export default function Step5Success({
     packageName: selectedPackage?.name,
     subscriptionName: selectedPlan?.name,
     subscriptionCode,
-    batteryId: battery?.shortId,
+    // Use actualBatteryId from ATT service (OPID/PPID), fallback to shortId (BLE device name)
+    batteryId: battery?.actualBatteryId || battery?.shortId,
     batteryLevel: battery?.chargeLevel,
     paymentReference,
     amountPaid: totalPurchaseAmount,


### PR DESCRIPTION
Update battery ID displays across Attendant and Salesperson workflows to prioritize the actual battery ID from the ATT process over the BLE device name.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1566146-cc3b-428c-8a1e-5198f207e2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b1566146-cc3b-428c-8a1e-5198f207e2cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

