### PR TITLE
Fix ble connection bug

### DIFF
--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -424,8 +424,65 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
       setReadingPhase('idle');
       setDtaData(null);
       isProcessingRef.current = false;
+      isDeviceMatchingRef.current = false;
     }
   }, [connectionState.connectionFailed, connectionState.requiresBluetoothReset, connectionState.error, pendingBatteryId, clearMatchTimers, connectionForceBleReset, log]);
+
+  // ============================================
+  // HANDLE SERVICE READING ERRORS
+  // CRITICAL: This effect ensures state is cleaned up when service reading fails
+  // Without this, readingPhase stays stuck at 'dta'/'att' and the next scan attempt fails
+  // ============================================
+  useEffect(() => {
+    // Only trigger when there's a service error AND we're in a reading phase
+    if (serviceState.error && readingPhase !== 'idle') {
+      log('Service reading error detected:', serviceState.error);
+      log('Current readingPhase:', readingPhase, '- cleaning up state');
+      
+      // Check if this error requires a Bluetooth reset
+      const errorLower = serviceState.error.toLowerCase();
+      const requiresReset = errorLower.includes('not connected') ||
+                           errorLower.includes('connection lost') ||
+                           errorLower.includes('connection stuck') ||
+                           errorLower.includes('macaddress') ||
+                           errorLower.includes('mac address');
+      
+      if (requiresReset) {
+        log('Service error requires BLE reset');
+        // Force disconnect any connected device to clear native layer state
+        if (connectedDevice) {
+          connectionDisconnect(connectedDevice);
+        }
+        // Also force reset the connection state to clear any stuck MACs in sessionStorage
+        connectionForceBleReset();
+      }
+      
+      // Notify error callback
+      onErrorRef.current?.(serviceState.error, requiresReset);
+      
+      // CRITICAL: Reset ALL pending state so the next scan attempt can work
+      setPendingBatteryId(null);
+      setPendingScanType(null);
+      setReadingPhase('idle');
+      setDtaData(null);
+      isProcessingRef.current = false;
+      isDeviceMatchingRef.current = false;
+      
+      // Update state to reflect failure
+      setState(prev => ({
+        ...prev,
+        isConnecting: false,
+        isReadingEnergy: false,
+        isReadingService: false,
+        readingPhase: 'idle',
+        connectionFailed: true,
+        requiresBluetoothReset: requiresReset,
+        error: serviceState.error,
+      }));
+      
+      log('State cleanup complete after service error');
+    }
+  }, [serviceState.error, readingPhase, connectedDevice, connectionDisconnect, connectionForceBleReset, log]);
 
   // ============================================
   // PUBLIC API


### PR DESCRIPTION
Fixes BLE connection getting stuck after a service reading failure.

Previously, when `useBleServiceReader` encountered an error during DTA reading, `useFlowBatteryScan` failed to reset its internal state (`readingPhase`, `pendingBatteryId`, `isProcessingRef`). This left the app in a stuck state, preventing any further BLE connection attempts. The fix introduces an effect in `useFlowBatteryScan` to listen for `serviceState.error` and correctly reset all relevant states, along with improved error handling in `useBleServiceReader` to ensure proper disconnection and ref resets.

---
<a href="https://cursor.com/background-agent?bcId=bc-4fc44b94-c7fb-441c-90f1-4f1e2561b7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4fc44b94-c7fb-441c-90f1-4f1e2561b7fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

