### PR TITLE
Battery reconnection logic

### DIFF
--- a/src/components/shared/BatteryScanBind.tsx
+++ b/src/components/shared/BatteryScanBind.tsx
@@ -148,6 +148,7 @@ export default function BatteryScanBind({
       {/* BLE Connection Progress Overlay */}
       {isConnecting && (
         <BleConnectionProgress
+          key={bleScanState?.scanStartTime || 'progress'}
           bleScanState={bleScanState!}
           onCancel={onCancelBleOperation}
         />
@@ -331,6 +332,7 @@ export function BatteryScanBindWithHook({
 
       {isConnecting && (
         <BleConnectionProgress
+          key={legacyState.scanStartTime || 'progress'}
           bleScanState={legacyState}
           onCancel={cancel}
         />

--- a/src/lib/hooks/ble/types.ts
+++ b/src/lib/hooks/ble/types.ts
@@ -121,6 +121,8 @@ export interface BleFullState {
   error: string | null;
   connectionFailed: boolean;
   requiresBluetoothReset: boolean;
+  /** Timestamp when the current scan/connection attempt started */
+  scanStartTime?: number;
 }
 
 // ============================================

--- a/src/lib/hooks/ble/useBatteryScanAndBind.ts
+++ b/src/lib/hooks/ble/useBatteryScanAndBind.ts
@@ -396,6 +396,10 @@ export function useBatteryScanAndBind(options: UseBatteryScanAndBindOptions = {}
     // Clear any previous match timers
     clearMatchTimers();
     
+    // Clear previously detected devices to ensure we find the fresh device
+    // and don't match with stale data from a previous scan
+    scannerClearDevices();
+    
     // Enter device matching phase - this keeps isConnecting=true until we find a device
     isDeviceMatchingRef.current = true;
     
@@ -406,6 +410,7 @@ export function useBatteryScanAndBind(options: UseBatteryScanAndBindOptions = {}
       connectionProgress: 0, // Start at 0%
       error: null,
       connectionFailed: false,
+      scanStartTime: Date.now(), // Track start time for UI timer reset
     }));
     
     // Set up device matching
@@ -484,6 +489,7 @@ export function useBatteryScanAndBind(options: UseBatteryScanAndBindOptions = {}
     
     clearMatchTimers();
     scannerStopScan();
+    scannerClearDevices(); // Clear devices on cancel to ensure fresh state for next time
     cancelConnection();
     serviceReaderCancelRead();
     


### PR DESCRIPTION
Fixes progress bar timer not resetting and prevents automatic reconnection to previous batteries.

The `BleConnectionProgress` component's internal timer was not resetting on subsequent connection attempts, leading to a "no timer" display. This is resolved by using `scanStartTime` as a React `key`, forcing the component to remount and reset its state. Additionally, the BLE scanner was retaining previously discovered devices, causing it to attempt connection to a cached battery instead of waiting for a new scan prompt. Clearing scanner devices on scan initiation and cancellation ensures a fresh scan for each attempt.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d725435-4334-49c5-8c47-94c5d7a08c17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1d725435-4334-49c5-8c47-94c5d7a08c17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

