### PR TITLE
Battery reconnection logic

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -385,7 +385,10 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
   const cancelBleOperation = useCallback(() => {
     console.info('=== Cancelling BLE operation via hook ===');
     clearScanTimeout();
-    hookCancelOperation();
+    // IMPORTANT: BleProgressModal calls onCancel when its 60s countdown expires.
+    // That is a TIMEOUT cancel and must be forced, even if the hook is mid-read,
+    // otherwise we can end up with a stuck progress UI and unexpected reconnection attempts.
+    hookCancelOperation({ reason: 'timeout', force: true });
     setIsScanning(false);
     scanTypeRef.current = null;
   }, [clearScanTimeout, hookCancelOperation]);

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -489,7 +489,10 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
 
   // Cancel BLE operation - delegates to hook
   const cancelBleOperation = useCallback(() => {
-    hookCancelOperation();
+    // IMPORTANT: BleProgressModal calls onCancel when its 60s countdown expires.
+    // That is a TIMEOUT cancel and must be forced, otherwise we can get stuck UI
+    // and "reconnect without user prompt" due to lingering BLE retries.
+    hookCancelOperation({ reason: 'timeout', force: true });
     setIsScannerOpening(false);
     scanTypeRef.current = null;
   }, [hookCancelOperation]);


### PR DESCRIPTION
Fixes stuck BLE progress modal and prevents unprompted auto-reconnections by ensuring forceful cancellation on timeout and clearing hidden retry timers in Attendant and Sales workflows.

When the connection modal timed out, the BLE cancellation logic could refuse to disconnect if it was mid-read, leaving the UI stuck. Additionally, an internal retry timer was not being cleared, causing the system to attempt reconnecting in the background without user interaction, sometimes to a different battery. This PR ensures that timeouts always trigger a full, forced disconnect and that all scheduled retries are cleared.

---
<a href="https://cursor.com/background-agent?bcId=bc-f400b401-8d60-492d-be82-7b46e4da50b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f400b401-8d60-492d-be82-7b46e4da50b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

