### PR TITLE
Ble dta read hang

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -382,10 +382,11 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
   }, [clearScanTimeout]);
 
   // Cancel/Close ongoing BLE operation - delegates to hook
-  const cancelBleOperation = useCallback(() => {
-    console.info('=== Cancelling BLE operation via hook ===');
+  // @param force - If true, forces cancellation even during active reading (used by timeout)
+  const cancelBleOperation = useCallback((force?: boolean) => {
+    console.info('=== Cancelling BLE operation via hook ===', force ? '(forced)' : '');
     clearScanTimeout();
-    hookCancelOperation();
+    hookCancelOperation(force);
     setIsScanning(false);
     scanTypeRef.current = null;
   }, [clearScanTimeout, hookCancelOperation]);

--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -488,8 +488,9 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
   }, [hookStopScanning]);
 
   // Cancel BLE operation - delegates to hook
-  const cancelBleOperation = useCallback(() => {
-    hookCancelOperation();
+  // @param force - If true, forces cancellation even during active reading (used by timeout)
+  const cancelBleOperation = useCallback((force?: boolean) => {
+    hookCancelOperation(force);
     setIsScannerOpening(false);
     scanTypeRef.current = null;
   }, [hookCancelOperation]);

--- a/src/components/shared/BleProgressModal.tsx
+++ b/src/components/shared/BleProgressModal.tsx
@@ -11,8 +11,12 @@ export interface BleProgressModalProps {
   bleScanState: FlowBleScanState;
   /** ID of the battery being connected (for display) */
   pendingBatteryId: string | null;
-  /** Callback when user clicks cancel/close */
-  onCancel: () => void;
+  /** 
+   * Callback when user clicks cancel/close or when timeout expires.
+   * @param force - If true, this is a forced cancellation (timeout or stuck state).
+   *                Default is false (user-initiated cancel).
+   */
+  onCancel: (force?: boolean) => void;
 }
 
 /**
@@ -93,9 +97,11 @@ export function BleProgressModal({
         setCountdown(remaining);
         
         // When countdown reaches 0, automatically cancel and close the modal
+        // Pass force=true to ensure cancellation happens even if reading is in progress
+        // This prevents the modal from hanging when DTA reading gets stuck
         if (remaining <= 0 && !hasTimedOut) {
           setHasTimedOut(true);
-          onCancel(); // This triggers cleanup: stops scanning, cancels connection, resets state
+          onCancel(true); // Force cancel - triggers cleanup even during stuck reads
         }
       }, 1000);
       

--- a/src/lib/hooks/ble/useBleDeviceConnection.ts
+++ b/src/lib/hooks/ble/useBleDeviceConnection.ts
@@ -205,15 +205,18 @@ export function useBleDeviceConnection(options: UseBleDeviceConnectionOptions = 
 
   /**
    * Cancel ongoing connection attempt
+   * 
+   * @param force - If true, forces cancellation even if already connected.
+   *                This is used when the operation needs to be forcefully terminated.
    */
-  const cancelConnection = useCallback(() => {
-    if (isConnectedRef.current) {
-      log('Cannot cancel - already connected');
+  const cancelConnection = useCallback((force?: boolean) => {
+    if (isConnectedRef.current && !force) {
+      log('Cannot cancel - already connected (use force=true to override)');
       toast('Please wait while operation completes...', { icon: '⏳' });
       return false;
     }
 
-    log('Cancelling connection, invalidating session:', connectionSessionRef.current);
+    log('Cancelling connection', force ? '(forced)' : '', ', invalidating session:', connectionSessionRef.current);
     clearAllTimeouts();
     
     if (window.WebViewJavascriptBridge && pendingMacRef.current) {


### PR DESCRIPTION
Fixes BLE DTA read hang by adding error handling and enabling forced cancellation.

Previously, if the DTA (energy data) read timed out or failed, the application's state would remain stuck, preventing the progress modal from closing and blocking user cancellation. This was due to missing error handling in `useFlowBatteryScan` for `serviceState.error` and blocking conditions in `cancelOperation` and `cancelConnection`. The changes ensure that service read errors reset the application state and allow for forced cancellation, resolving the indefinite hang.

---
<a href="https://cursor.com/background-agent?bcId=bc-683eb46e-8db7-41f7-9ed8-5c001e3f672d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-683eb46e-8db7-41f7-9ed8-5c001e3f672d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

