### PR TITLE
Ble dta read hang fix

### DIFF
--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -489,6 +489,10 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
    */
   const startScanning = useCallback(() => {
     log('Starting BLE scanning');
+    // CRITICAL: Clear force closed flag when starting a new scan
+    // This allows the sync effect to properly manage state again
+    // Without this, after a force close, subsequent scans won't update state properly
+    forceClosedRef.current = false;
     scannerStartScan();
   }, [scannerStartScan, log]);
 
@@ -671,8 +675,10 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
   const resetState = useCallback(() => {
     log('Resetting state');
     
-    // Set force closed flag to ensure sync effect doesn't override
-    forceClosedRef.current = true;
+    // CRITICAL: Clear force closed flag to allow sync effect to manage state properly
+    // Previously this was set to true, which prevented subsequent scans from working
+    // after a force close (the sync effect would keep returning INITIAL_STATE)
+    forceClosedRef.current = false;
     
     clearMatchTimers();
     scannerClearDevices();


### PR DESCRIPTION
Reset `forceClosedRef` when starting a new BLE scan or resetting state to allow subsequent scanning operations to proceed correctly.

The `forceClosedRef` flag was introduced to prevent the sync effect from overriding `INITIAL_STATE` after a force-close. However, it was incorrectly set to `true` during `resetState()` and not cleared in `startScanning()`, causing the sync effect to continuously return `INITIAL_STATE` and block new scans. This PR ensures the flag is cleared when preparing for a new operation.

---
<a href="https://cursor.com/background-agent?bcId=bc-df9725ed-f2e8-4731-8526-eae05c25b024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-df9725ed-f2e8-4731-8526-eae05c25b024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

