### PR TITLE
Ble connection cancel button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4152,6 +4152,32 @@ html.theme-transition *::after {
   line-height: 1.5;
 }
 
+/* BLE Progress Cancel Button - Escape hatch for stuck connections */
+.ble-progress-cancel-button {
+  margin-top: 20px;
+  padding: 12px 24px;
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  width: 100%;
+}
+
+.ble-progress-cancel-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.3);
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.ble-progress-cancel-button:active {
+  background: rgba(255, 255, 255, 0.15);
+  transform: scale(0.98);
+}
+
 /* BLE Progress Icon Warning State */
 .ble-progress-icon-warning {
   background: linear-gradient(145deg, #fbbf24 0%, #f59e0b 100%);
@@ -4284,6 +4310,12 @@ html.theme-transition *::after {
   
   .ble-cancel-button {
     margin-top: 14px;
+    padding: 10px 20px;
+    font-size: 13px;
+  }
+  
+  .ble-progress-cancel-button {
+    margin-top: 16px;
     padding: 10px 20px;
     font-size: 13px;
   }

--- a/src/components/shared/BleProgressModal.tsx
+++ b/src/components/shared/BleProgressModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import type { FlowBleScanState } from '@/lib/hooks/ble';
+import { useI18n } from '@/i18n';
 
 // Connection process typically takes 25-40 seconds, countdown from 60s
 const COUNTDOWN_START_SECONDS = 60;
@@ -38,6 +39,8 @@ export function BleProgressModal({
   pendingBatteryId,
   onCancel,
 }: BleProgressModalProps) {
+  const { t } = useI18n();
+  
   // Countdown timer state
   const [countdown, setCountdown] = useState(COUNTDOWN_START_SECONDS);
   // Track if we already triggered timeout cancel to prevent multiple calls
@@ -292,6 +295,15 @@ export function BleProgressModal({
           <p className="ble-progress-help">
             {getHelpText()}
           </p>
+
+          {/* Cancel Button - Always visible as escape hatch for stuck connections */}
+          <button
+            type="button"
+            className="ble-progress-cancel-button"
+            onClick={() => onCancel(true)}
+          >
+            {t('ble.cancelConnection') || 'Cancel'}
+          </button>
         </div>
       </div>
     </div>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1248,6 +1248,7 @@
   "ble.phase.readingDta.subtitle": "Getting energy data from battery...",
   "ble.phase.readingAtt.title": "Reading Battery ID",
   "ble.phase.readingAtt.subtitle": "Getting battery identifier...",
+  "ble.cancelConnection": "Cancel",
   
   "rider.phoneNumber": "Phone Number",
   "rider.enterPhone": "Enter your phone number",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1239,6 +1239,7 @@
   "ble.phase.readingDta.subtitle": "Obtention des données d'énergie de la batterie...",
   "ble.phase.readingAtt.title": "Lecture ID Batterie",
   "ble.phase.readingAtt.subtitle": "Obtention de l'identifiant de la batterie...",
+  "ble.cancelConnection": "Annuler",
   
   "rider.phoneNumber": "Numéro de téléphone",
   "rider.enterPhone": "Entrez votre numéro de téléphone",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1150,6 +1150,7 @@
   "ble.phase.readingDta.subtitle": "正在获取电池能量数据...",
   "ble.phase.readingAtt.title": "读取电池ID",
   "ble.phase.readingAtt.subtitle": "正在获取电池标识...",
+  "ble.cancelConnection": "取消",
   
   "rider.phoneNumber": "电话号码",
   "rider.enterPhone": "输入您的电话号码",


### PR DESCRIPTION
Add a cancel button to the BLE connection progress modal to provide an escape hatch for stuck connections and ensure a complete BLE state reset.

This button addresses scenarios where the progress modal might hang indefinitely, preventing further connection attempts. Clicking "Cancel" now triggers a full BLE reset, clearing all relevant `sessionStorage` and internal states, allowing the user to start fresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-45530638-c20f-4142-addd-2779150cceb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45530638-c20f-4142-addd-2779150cceb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an always-visible cancel button to the BLE connection modal that triggers a full BLE reset, with supporting styles and i18n strings.
> 
> - **UI/Modal**:
>   - Add always-visible `Cancel` button in `src/components/shared/BleProgressModal.tsx` invoking `onCancel(true)` and localized via `t('ble.cancelConnection')`.
>   - Minor modal copy/structure adjustments around help text and steps.
> - **Styles**:
>   - Add `.ble-progress-cancel-button` styles and responsive tweaks in `src/app/globals.css`.
> - **i18n**:
>   - Introduce `ble.cancelConnection` key in `en.json`, `fr.json`, and `zh.json`.
> - **BLE Hook**:
>   - Update `cancelOperation` in `useFlowBatteryScan.ts` to perform a complete BLE reset on `force=true` (`connectionForceBleReset`, `scannerClearDevices`), ensuring session cleanup and immediate modal close; adjust deps accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0c8a69ac03e19f2e3dfb3c545ba9af628e31a53. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->