### PR TITLE
Progress modal cancel icon

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3888,11 +3888,51 @@ html.theme-transition *::after {
 /* ===================== */
 
 .ble-progress-container {
+  position: relative;
   background: linear-gradient(145deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
   padding: 24px 20px;
   box-shadow: 0 20px 60px -15px rgba(0, 0, 0, 0.5);
+}
+
+/* Close Icon - Top Right Cancel Button */
+.ble-progress-close-icon {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  z-index: 10;
+}
+
+.ble-progress-close-icon svg {
+  width: 18px;
+  height: 18px;
+  color: rgba(255, 255, 255, 0.7);
+  transition: color 0.2s ease;
+}
+
+.ble-progress-close-icon:hover {
+  background: rgba(239, 68, 68, 0.2);
+  border-color: rgba(239, 68, 68, 0.4);
+}
+
+.ble-progress-close-icon:hover svg {
+  color: #ef4444;
+}
+
+.ble-progress-close-icon:active {
+  transform: scale(0.95);
+  background: rgba(239, 68, 68, 0.3);
 }
 
 .ble-progress-header {
@@ -4314,10 +4354,16 @@ html.theme-transition *::after {
     font-size: 13px;
   }
   
-  .ble-progress-cancel-button {
-    margin-top: 16px;
-    padding: 10px 20px;
-    font-size: 13px;
+  .ble-progress-close-icon {
+    top: 10px;
+    right: 10px;
+    width: 32px;
+    height: 32px;
+  }
+  
+  .ble-progress-close-icon svg {
+    width: 16px;
+    height: 16px;
   }
   
   .ble-progress-help {

--- a/src/components/shared/BleProgressModal.tsx
+++ b/src/components/shared/BleProgressModal.tsx
@@ -163,6 +163,19 @@ export function BleProgressModal({
     <div className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center">
       <div className="w-full max-w-md px-4">
         <div className="ble-progress-container">
+          {/* Close/Cancel Icon - Top Right */}
+          <button
+            type="button"
+            className="ble-progress-close-icon"
+            onClick={() => onCancel(true)}
+            aria-label={t('ble.cancelConnection') || 'Cancel'}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+
           {/* Header */}
           <div className="ble-progress-header">
             <div className={`ble-progress-icon ${bleScanState.requiresBluetoothReset ? 'ble-progress-icon-warning' : ''}`}>
@@ -295,15 +308,6 @@ export function BleProgressModal({
           <p className="ble-progress-help">
             {getHelpText()}
           </p>
-
-          {/* Cancel Button - Always visible as escape hatch for stuck connections */}
-          <button
-            type="button"
-            className="ble-progress-cancel-button"
-            onClick={() => onCancel(true)}
-          >
-            {t('ble.cancelConnection') || 'Cancel'}
-          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Replace `BleProgressModal`'s bottom cancel button with a top-right close icon to make the modal more compact and maintain clear visibility of the cancel action.

---
<a href="https://cursor.com/background-agent?bcId=bc-6990881c-8cca-40b1-9388-b92cca8670d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6990881c-8cca-40b1-9388-b92cca8670d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the bottom cancel button with a top-right close icon in `BleProgressModal`, adding corresponding styles and small-screen tweaks.
> 
> - **UI/Modal**:
>   - Replace bottom `Cancel` button with a top-right close icon in `src/components/shared/BleProgressModal.tsx` that calls `onCancel(true)`.
>   - Remove old `ble-progress-cancel-button` JSX.
> - **Styles**:
>   - Add `ble-progress-close-icon` styles, hover/active states, and responsive sizing in `src/app/globals.css`.
>   - Set `ble-progress-container` to `position: relative` to position the icon.
>   - Add small-screen adjustments for the close icon.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b876aa479b4763eea1e4c2cb158dc5097a8b2c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->