### PR TITLE
Ble connection state reset

### DIFF
--- a/src/components/shared/BleDeviceList.tsx
+++ b/src/components/shared/BleDeviceList.tsx
@@ -318,6 +318,12 @@ export default function BleDeviceList({
             <span className="ble-device-empty-hint">
               {t('ble.noDevicesHint') || 'Make sure the battery is powered on and Bluetooth is enabled'}
             </span>
+            {/* Hint to restart BLE scanning - shown when scanner was stopped (e.g., after timeout/cancel) */}
+            {onRescan && (
+              <span className="ble-device-restart-hint">
+                {t('ble.tapRefreshToRestart') || 'Tap the ↻ icon above to restart scanning'}
+              </span>
+            )}
           </div>
         )}
 
@@ -750,6 +756,17 @@ export default function BleDeviceList({
           display: block;
           margin-top: ${spacing[2]};
           font-size: ${fontSize.xs};
+        }
+
+        .ble-device-restart-hint {
+          display: block;
+          margin-top: ${spacing[3]};
+          padding: ${spacing[2]} ${spacing[3]};
+          font-size: ${fontSize.xs};
+          color: ${colors.brand.primary};
+          background: ${colors.brand.primary}15;
+          border-radius: ${radius.md};
+          font-weight: ${fontWeight.medium};
         }
 
         .ble-device-skeleton {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1224,6 +1224,7 @@
   "ble.searchDevices": "Search by name or ID (e.g., 0006)...",
   "ble.noDevicesFound": "No devices found nearby",
   "ble.noDevicesHint": "Make sure the battery is powered on and Bluetooth is enabled",
+  "ble.tapRefreshToRestart": "Tap the ↻ icon above to restart scanning",
   "ble.noMatchingDevices": "No devices match your search",
   "ble.rescan": "Rescan",
   "ble.stopScanning": "Stop scanning",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1215,6 +1215,7 @@
   "ble.searchDevices": "Rechercher par nom ou ID (ex: 0006)...",
   "ble.noDevicesFound": "Aucun appareil trouvé à proximité",
   "ble.noDevicesHint": "Assurez-vous que la batterie est allumée et que le Bluetooth est activé",
+  "ble.tapRefreshToRestart": "Appuyez sur l'icône ↻ ci-dessus pour relancer la recherche",
   "ble.noMatchingDevices": "Aucun appareil ne correspond à votre recherche",
   "ble.rescan": "Rescanner",
   "ble.stopScanning": "Arrêter la recherche",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1126,6 +1126,7 @@
   "ble.searchDevices": "按名称或ID搜索（如：0006）...",
   "ble.noDevicesFound": "附近未找到设备",
   "ble.noDevicesHint": "请确保电池已开启且蓝牙已启用",
+  "ble.tapRefreshToRestart": "点击上方 ↻ 图标重新开始扫描",
   "ble.noMatchingDevices": "没有匹配您搜索的设备",
   "ble.rescan": "重新扫描",
   "ble.stopScanning": "停止扫描",

--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -644,32 +644,19 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
     
     // Set timeout for device matching
     matchTimeoutRef.current = setTimeout(() => {
-      clearMatchTimers();
-      scannerStopScan();
-      
-      // Exit device matching phase
-      isDeviceMatchingRef.current = false;
-      
-      log('Device matching timed out');
-      
-      setState(prev => ({
-        ...prev,
-        isScanning: false,
-        isConnecting: false,
-        error: 'Device may already be connected',
-        connectionFailed: true,
-      }));
+      log('Device matching timed out - using consolidated cleanup');
       
       toast.error('Device may already be connected. Try turning Bluetooth off and on, then try again.');
       onErrorRef.current?.('Device may already be connected');
       
-      // Clear pending state
-      setPendingBatteryId(null);
-      setPendingScanType(null);
+      // Use consolidated cleanup - this handles everything
+      cleanupAllBleState(true);
+      
+      log('Device matching timeout handled via cleanupAllBleState');
     }, DEVICE_MATCH_TIMEOUT);
     
     return true;
-  }, [scannerScanState.isScanning, scannerStartScan, scannerStopScan, scannerGetDevices, scannerFindDeviceByNameSuffix, connectionConnect, clearMatchTimers, log]);
+  }, [scannerScanState.isScanning, scannerStartScan, scannerStopScan, scannerGetDevices, scannerFindDeviceByNameSuffix, connectionConnect, clearMatchTimers, cleanupAllBleState, log]);
 
   /**
    * Cancel ongoing operation


### PR DESCRIPTION
Consolidates BLE cleanup into a single function to ensure full state reset on modal close, timeout, or error, preventing stale device issues, and adds a hint to restart scanning.

The previous cleanup logic was fragmented, leading to stale detected devices and connection states persisting, causing "Bluetooth macAddress is not match" errors. This PR centralizes all cleanup, including stopping scans, clearing detected devices, resetting service reader state, and clearing all relevant `sessionStorage` items, ensuring a fresh start. It also guides users when scanning stops.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cc8c3d5-2d5f-4107-9e50-1cdd1ca81e23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5cc8c3d5-2d5f-4107-9e50-1cdd1ca81e23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes BLE cleanup into a single `cleanupAllBleState` used across scan/connect/read flows, and adds a UI/i18n hint to restart scanning.
> 
> - **BLE scan flow (hook)**:
>   - Introduce consolidated `cleanupAllBleState(setForceClosedFlag)` in `src/lib/hooks/ble/useFlowBatteryScan.ts` to reset timers, scanning, detected devices, service reader, connection state, and sessionStorage; used across effects and handlers.
>   - Replace scattered cleanup with centralized calls on: connection failures, service read failures/timeouts, device match timeout, cancel/reset/retry/force reset, start/stop scanning, and unmount.
>   - Ensure fresh scans by cleaning before `startScanning` and full teardown on `stopScanning`.
> - **UI**:
>   - `src/components/shared/BleDeviceList.tsx`: show restart hint when not scanning and `onRescan` is available; add `.ble-device-restart-hint` styling.
> - **i18n**:
>   - Add `ble.tapRefreshToRestart` to `en.json`, `fr.json`, `zh.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc9012cbd04b42716c79125476ec6e985aa59332. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->