### PR TITLE
Ppid arrow cleanup

### DIFF
--- a/src/lib/hooks/ble/index.ts
+++ b/src/lib/hooks/ble/index.ts
@@ -110,8 +110,9 @@ export {
   // Energy extraction
   extractEnergyFromDta,
   createBatteryData,
-  // ATT battery ID extraction
+  // ATT battery ID extraction & cleanup
   extractActualBatteryIdFromAtt,
+  cleanBatteryId,
   // QR parsing
   parseBatteryIdFromQr,
   parseMacAddressFromQr,


### PR DESCRIPTION
Add `cleanBatteryId` function and apply it to `extractActualBatteryIdFromAtt` to remove arrow characters from battery IDs.

---
<a href="https://cursor.com/background-agent?bcId=bc-0eba6141-fd36-41f4-931b-f0a14d44761a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0eba6141-fd36-41f4-931b-f0a14d44761a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `cleanBatteryId` and applies it to `extractActualBatteryIdFromAtt` (opid/ppid) to remove '<' and '>' characters; exports the utility.
> 
> - **BLE Utilities**:
>   - `src/lib/hooks/ble/energyUtils.ts`:
>     - Add `cleanBatteryId(batteryId)` to remove `"<"` and `">"` from IDs.
>     - Use `cleanBatteryId` in `extractActualBatteryIdFromAtt` for both `opid` and `ppid`.
>   - `src/lib/hooks/ble/index.ts`:
>     - Export `cleanBatteryId` alongside `extractActualBatteryIdFromAtt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f489dc243fe45c10cf156e2702e89cda13b1bbe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->