### PR TITLE
Ble device detection failure

### DIFF
--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -200,7 +200,7 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
    * Cleans up:
    * - Match timers (device discovery polling)
    * - BLE scanning (stops native scan)
-   * - Detected devices list (prevents stale device data) - ONLY if clearDevices=true
+   * - Detected devices list (prevents stale device data)
    * - Service reader state (cancels pending reads)
    * - BLE connection state AND sessionStorage:
    *   - connectedDeviceMac
@@ -212,14 +212,12 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
    * @param setForceClosedFlag - If true, sets forceClosedRef to prevent sync effect 
    *                             from overriding state. Use true for cancel/close operations,
    *                             false for reset/retry operations where we want scanning to resume.
-   * @param clearDevices - If true, clears the detected devices list. Default true.
-   *                       Set to false when resetting for retry to preserve discovered devices.
    */
-  const cleanupAllBleState = useCallback((setForceClosedFlag: boolean = true, clearDevices: boolean = true) => {
-    log('=== CLEANUP: Resetting BLE state ===');
+  const cleanupAllBleState = useCallback((setForceClosedFlag: boolean = true) => {
+    log('=== CLEANUP: Resetting ALL BLE state ===');
     log('  - Clearing match timers');
     log('  - Stopping BLE scan');
-    log('  - Clearing detected devices:', clearDevices);
+    log('  - Clearing detected devices');
     log('  - Resetting service reader');
     log('  - Force resetting BLE connection (clears sessionStorage)');
     log('  - setForceClosedFlag:', setForceClosedFlag);
@@ -230,14 +228,9 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
     // Clear all timers
     clearMatchTimers();
     
-    // Stop scanning
+    // Stop scanning and clear detected devices
     scannerStopScan();
-    
-    // Only clear detected devices if requested
-    // When resetting for retry, we want to keep the devices for matching
-    if (clearDevices) {
-      scannerClearDevices();
-    }
+    scannerClearDevices();
     
     // Cancel any pending service reads
     serviceReaderCancelRead();


### PR DESCRIPTION
Preserve detected BLE devices during state resets and scan starts to prevent "No detected devices" errors when connecting to visible devices.

The `cleanupAllBleState` function, called by `resetState` and `startScanning`, previously cleared all detected BLE devices. This caused issues where devices were visible in the scanner but unavailable for selection or matching immediately after a retry or a new scan initiation, as the device list was prematurely emptied. This PR introduces a `clearDevices` parameter to `cleanupAllBleState` and sets it to `false` in `resetState` and `startScanning` to maintain the list of discovered devices. `stopScanning` was also made less destructive, only stopping the scan without clearing devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-859716ed-8def-4008-a2aa-bf9b5293d813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-859716ed-8def-4008-a2aa-bf9b5293d813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves detected BLE devices during stop/retry, adds a lightweight reset flow, and refines scanning/matching timers and retries.
> 
> - **BLE scanning lifecycle (`src/lib/hooks/ble/useFlowBatteryScan.ts`)**
>   - **Stop scanning**: Now only stops the native scan and clears match timers, preserving `detectedDevices` via `scannerStopScan()` and `clearMatchTimers()`.
>   - **Lightweight reset (`resetState`)**: Preserves `detectedDevices` while clearing timers/refs, canceling reads, and resetting connection/service reader and local state.
>   - **Retry flow**: `retryConnection` uses `resetState()` then restarts scanning with `scannerStartScan()`.
>   - **Start scanning**: Performs full cleanup (fresh scan) via `cleanupAllBleState(false)` before `scannerStartScan()`.
>   - **Docs/logging**: Updated comments/logs to clarify preservation of devices vs. full cleanup and to detail matching/reading phases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 788568ebc71d45e49b442b96bd62673f74c76de3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->