### PR TITLE
Progress modal state cleanup

### DIFF
--- a/src/lib/hooks/ble/bleErrors.ts
+++ b/src/lib/hooks/ble/bleErrors.ts
@@ -1,0 +1,372 @@
+'use client';
+
+/**
+ * BLE Error Handling Utilities
+ * 
+ * Centralized error handling for all BLE native layer responses.
+ * This provides a systematic way to parse, categorize, and handle
+ * all error responses from the native BLE layer.
+ * 
+ * Usage:
+ *   const result = parseBleResponse(responseData);
+ *   if (!result.success) {
+ *     // Handle error using result.error
+ *   }
+ */
+
+// ============================================
+// ERROR CODES
+// ============================================
+
+/**
+ * Known BLE response codes from native layer
+ * Add new codes here as they are discovered
+ */
+export const BLE_RESP_CODES = {
+  SUCCESS: '200',
+  // Connection errors
+  DEVICE_NOT_CONNECTED: '8',
+  MAC_ADDRESS_MISMATCH: '7',
+  // Add more codes as discovered
+} as const;
+
+// ============================================
+// ERROR CATEGORIES
+// ============================================
+
+/**
+ * Error categories determine how the error should be handled
+ */
+export type BleErrorCategory = 
+  | 'connection_lost'      // Device disconnected during operation
+  | 'mac_mismatch'         // Native layer has wrong MAC cached
+  | 'bluetooth_off'        // Bluetooth is disabled
+  | 'timeout'              // Operation timed out
+  | 'parse_error'          // Failed to parse response
+  | 'service_error'        // Service-level error
+  | 'unknown';             // Unknown error
+
+/**
+ * Parsed BLE error with categorization
+ */
+export interface BleError {
+  /** Error category for handling decisions */
+  category: BleErrorCategory;
+  /** Human-readable error message */
+  message: string;
+  /** Whether user needs to toggle Bluetooth off/on */
+  requiresBluetoothReset: boolean;
+  /** Original response code from native layer */
+  respCode?: string;
+  /** Original description from native layer */
+  respDesc?: string;
+  /** Raw response data for debugging */
+  rawResponse?: unknown;
+}
+
+/**
+ * Result of parsing a BLE response
+ */
+export interface BleResponseResult {
+  /** Whether the operation was successful */
+  success: boolean;
+  /** Error details if not successful */
+  error?: BleError;
+  /** Parsed data if successful */
+  data?: unknown;
+}
+
+// ============================================
+// ERROR PATTERNS
+// ============================================
+
+/**
+ * Patterns to detect specific error types from respDesc
+ * These are checked case-insensitively
+ */
+const ERROR_PATTERNS: Array<{
+  patterns: string[];
+  category: BleErrorCategory;
+  requiresReset: boolean;
+  message: string;
+}> = [
+  // Device not connected errors
+  {
+    patterns: [
+      'bluetooth device not connected',
+      'device not connected',
+      'not connected',
+      'connection lost',
+      'disconnected',
+    ],
+    category: 'connection_lost',
+    requiresReset: true,
+    message: 'Bluetooth device not connected. Please turn Bluetooth OFF then ON.',
+  },
+  // MAC address mismatch errors
+  {
+    patterns: [
+      'macaddress is not match',
+      'mac address is not match',
+      'macaddress not match',
+      'mac address mismatch',
+      'wrong mac',
+    ],
+    category: 'mac_mismatch',
+    requiresReset: true,
+    message: 'Bluetooth connection stuck. Please turn Bluetooth OFF then ON.',
+  },
+  // Bluetooth off errors
+  {
+    patterns: [
+      'bluetooth is off',
+      'bluetooth off',
+      'bluetooth disabled',
+      'enable bluetooth',
+      'turn on bluetooth',
+    ],
+    category: 'bluetooth_off',
+    requiresReset: true,
+    message: 'Bluetooth is turned off. Please enable Bluetooth.',
+  },
+  // Timeout errors
+  {
+    patterns: [
+      'timeout',
+      'timed out',
+      'operation timeout',
+    ],
+    category: 'timeout',
+    requiresReset: false,
+    message: 'Operation timed out. Please try again.',
+  },
+];
+
+/**
+ * Map of known response codes to error categories
+ */
+const RESP_CODE_MAP: Record<string, {
+  category: BleErrorCategory;
+  requiresReset: boolean;
+  defaultMessage: string;
+}> = {
+  '7': {
+    category: 'mac_mismatch',
+    requiresReset: true,
+    defaultMessage: 'Bluetooth connection stuck. Please turn Bluetooth OFF then ON.',
+  },
+  '8': {
+    category: 'connection_lost',
+    requiresReset: true,
+    defaultMessage: 'Bluetooth device not connected. Please turn Bluetooth OFF then ON.',
+  },
+  // Add more codes as discovered
+};
+
+// ============================================
+// PARSER FUNCTIONS
+// ============================================
+
+/**
+ * Detect error category from response description
+ */
+function detectCategoryFromDesc(respDesc: string): {
+  category: BleErrorCategory;
+  requiresReset: boolean;
+  message: string;
+} | null {
+  const lowerDesc = respDesc.toLowerCase();
+  
+  for (const pattern of ERROR_PATTERNS) {
+    for (const p of pattern.patterns) {
+      if (lowerDesc.includes(p)) {
+        return {
+          category: pattern.category,
+          requiresReset: pattern.requiresReset,
+          message: pattern.message,
+        };
+      }
+    }
+  }
+  
+  return null;
+}
+
+/**
+ * Parse a BLE native layer response and extract error information
+ * 
+ * @param responseData - Raw response from native layer (string or object)
+ * @returns Parsed result with success flag and error details
+ */
+export function parseBleResponse(responseData: unknown): BleResponseResult {
+  // Handle null/undefined
+  if (responseData === null || responseData === undefined) {
+    return { success: true };
+  }
+  
+  // Try to parse if string
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = typeof responseData === 'string' 
+      ? JSON.parse(responseData) 
+      : responseData as Record<string, unknown>;
+  } catch {
+    // Not JSON - could be a simple acknowledgment
+    return { success: true, data: responseData };
+  }
+  
+  // Extract response code and description
+  // Support both flat and nested response structures
+  const respCode = String(
+    parsed?.respCode ?? 
+    (parsed?.responseData as Record<string, unknown>)?.respCode ?? 
+    ''
+  );
+  const respDesc = String(
+    parsed?.respDesc ?? 
+    (parsed?.responseData as Record<string, unknown>)?.respDesc ?? 
+    ''
+  );
+  const respData = parsed?.respData ?? (parsed?.responseData as Record<string, unknown>)?.respData;
+  
+  // Check for success
+  // Success = respCode is 200 OR respCode is empty (no error)
+  // OR respData is truthy (some responses use respData for success indication)
+  const isSuccess = 
+    respCode === '200' || 
+    respCode === 200 as unknown as string ||
+    (!respCode && respData !== false);
+  
+  if (isSuccess) {
+    return { success: true, data: parsed };
+  }
+  
+  // It's an error - categorize it
+  let category: BleErrorCategory = 'unknown';
+  let requiresReset = false;
+  let message = 'An error occurred. Please try again.';
+  
+  // First, check by response code
+  if (respCode && RESP_CODE_MAP[respCode]) {
+    const mapped = RESP_CODE_MAP[respCode];
+    category = mapped.category;
+    requiresReset = mapped.requiresReset;
+    message = mapped.defaultMessage;
+  }
+  
+  // Then, check by description (may override or supplement code-based detection)
+  if (respDesc) {
+    const detected = detectCategoryFromDesc(respDesc);
+    if (detected) {
+      category = detected.category;
+      requiresReset = detected.requiresReset;
+      message = detected.message;
+    }
+  }
+  
+  return {
+    success: false,
+    error: {
+      category,
+      message,
+      requiresBluetoothReset: requiresReset,
+      respCode: respCode || undefined,
+      respDesc: respDesc || undefined,
+      rawResponse: parsed,
+    },
+  };
+}
+
+/**
+ * Check if a BLE error requires Bluetooth reset
+ * Can be used with error messages from various sources
+ */
+export function requiresBluetoothReset(errorMessage: string): boolean {
+  const lower = errorMessage.toLowerCase();
+  
+  // Check all patterns that require reset
+  const resetPatterns = ERROR_PATTERNS
+    .filter(p => p.requiresReset)
+    .flatMap(p => p.patterns);
+  
+  // Also check for explicit reset instructions
+  const additionalPatterns = [
+    'toggle bluetooth',
+    'turn bluetooth off',
+    'bluetooth off then on',
+    'connection stuck',
+  ];
+  
+  const allPatterns = [...resetPatterns, ...additionalPatterns];
+  
+  return allPatterns.some(pattern => lower.includes(pattern));
+}
+
+/**
+ * Create a standardized error message for display
+ */
+export function getDisplayMessage(error: BleError): string {
+  return error.message;
+}
+
+/**
+ * Create a detailed error message for logging
+ */
+export function getDebugMessage(error: BleError): string {
+  return `[BLE Error] Category: ${error.category}, ` +
+    `Code: ${error.respCode || 'N/A'}, ` +
+    `Desc: ${error.respDesc || 'N/A'}, ` +
+    `RequiresReset: ${error.requiresBluetoothReset}`;
+}
+
+// ============================================
+// CLEANUP HELPERS
+// ============================================
+
+/**
+ * Force disconnect from all known BLE connections
+ * Call this when an error requires resetting BLE state
+ */
+export function forceDisconnectAll(log?: (...args: unknown[]) => void): void {
+  const logger = log || console.info;
+  
+  if (!window.WebViewJavascriptBridge) {
+    logger('[BLE Cleanup] Bridge not available');
+    return;
+  }
+  
+  // Get all stored MAC addresses
+  const connectedMac = sessionStorage.getItem('connectedDeviceMac');
+  const pendingMac = sessionStorage.getItem('pendingBleMac');
+  
+  // Disconnect from each
+  if (connectedMac) {
+    logger('[BLE Cleanup] Disconnecting from connectedMac:', connectedMac);
+    window.WebViewJavascriptBridge.callHandler('disconnectBle', connectedMac, () => {});
+  }
+  
+  if (pendingMac && pendingMac !== connectedMac) {
+    logger('[BLE Cleanup] Disconnecting from pendingMac:', pendingMac);
+    window.WebViewJavascriptBridge.callHandler('disconnectBle', pendingMac, () => {});
+  }
+  
+  // Clear storage
+  sessionStorage.removeItem('connectedDeviceMac');
+  sessionStorage.removeItem('pendingBleMac');
+  sessionStorage.removeItem('bleConnectionSession');
+  
+  logger('[BLE Cleanup] Session storage cleared');
+}
+
+// ============================================
+// EXPORTS
+// ============================================
+
+export default {
+  parseBleResponse,
+  requiresBluetoothReset,
+  getDisplayMessage,
+  getDebugMessage,
+  forceDisconnectAll,
+  BLE_RESP_CODES,
+};

--- a/src/lib/hooks/ble/index.ts
+++ b/src/lib/hooks/ble/index.ts
@@ -24,15 +24,19 @@
  * │ • Filter     │   │ • Retry          │   │ • Read any svc   │
  * │ • Match      │   │ • Timeout        │   │ • Handle errs    │
  * └──────────────┘   └──────────────────┘   └──────────────────┘
- *                            │                   │
- *                            │                   ▼
- *                            │          ┌──────────────────┐
- *                            │          │  energyUtils     │
- *                            │          │                  │
- *                            │          │ • Extract energy │
- *                            │          │ • Calculate cost │
- *                            │          │ • Parse QR       │
- *                            │          └──────────────────┘
+ *        │                   │                   │
+ *        │                   │                   │
+ *        └───────────────────┴───────────────────┘
+ *                            │
+ *              ┌─────────────┴─────────────┐
+ *              ▼                           ▼
+ *     ┌──────────────────┐       ┌──────────────────┐
+ *     │  energyUtils     │       │   bleErrors      │
+ *     │                  │       │                  │
+ *     │ • Extract energy │       │ • Parse response │
+ *     │ • Calculate cost │       │ • Categorize err │
+ *     │ • Parse QR       │       │ • Cleanup helper │
+ *     └──────────────────┘       └──────────────────┘
  *                            │
  *                            ▼
  *                   ┌──────────────────┐
@@ -124,6 +128,28 @@ export {
   formatEnergyWh,
   formatChargePercent,
 } from './energyUtils';
+
+// ============================================
+// ERROR HANDLING
+// ============================================
+
+export {
+  // Response parsing
+  parseBleResponse,
+  // Error detection
+  requiresBluetoothReset,
+  // Error messages
+  getDisplayMessage,
+  getDebugMessage,
+  // Cleanup helpers
+  forceDisconnectAll,
+  // Constants
+  BLE_RESP_CODES,
+  // Types
+  type BleError,
+  type BleErrorCategory,
+  type BleResponseResult,
+} from './bleErrors';
 
 // ============================================
 // HIGH-LEVEL COMPOSED HOOKS

--- a/src/lib/hooks/ble/useBleServiceReader.ts
+++ b/src/lib/hooks/ble/useBleServiceReader.ts
@@ -3,15 +3,14 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { toast } from 'react-hot-toast';
 import { initServiceBleData } from '@/app/utils';
-import type { BleServiceState, DtaServiceData } from './types';
+import type { BleServiceState } from './types';
+import { parseBleResponse, forceDisconnectAll, getDebugMessage } from './bleErrors';
 
 // ============================================
 // CONSTANTS
 // ============================================
 
 const SERVICE_READ_TIMEOUT = 20000; // 20 seconds
-const MAX_REFRESH_RETRIES = 2;
-const REFRESH_DELAY = 1500;
 
 const INITIAL_SERVICE_STATE: BleServiceState = {
   isReading: false,
@@ -41,6 +40,9 @@ export interface UseBleServiceReaderOptions {
  * 
  * Handles requesting and receiving BLE service data (like DTA for batteries).
  * Can be used after a device is connected to read specific services.
+ * 
+ * Uses centralized error handling from bleErrors.ts to systematically
+ * handle all error responses from the native BLE layer.
  * 
  * @example
  * const {
@@ -74,7 +76,6 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
   // ============================================
 
   const readTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const refreshRetryRef = useRef(0);
   const pendingServiceRef = useRef<string | null>(null);
   const pendingMacRef = useRef<string | null>(null);
 
@@ -99,6 +100,61 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
   }, []);
 
   // ============================================
+  // ERROR HANDLING
+  // ============================================
+
+  /**
+   * Handle BLE error response using centralized error handling
+   * This is called from multiple places (sync callback, async handlers)
+   */
+  const handleBleError = useCallback((responseData: unknown, source: string) => {
+    const result = parseBleResponse(responseData);
+    
+    if (result.success) {
+      return false; // Not an error
+    }
+    
+    const error = result.error!;
+    log(`BLE error from ${source}:`, getDebugMessage(error));
+    
+    // Clear timeout and pending state
+    clearReadTimeout();
+    toast.dismiss('service-refresh');
+    
+    // Force disconnect if needed
+    if (error.requiresBluetoothReset) {
+      forceDisconnectAll(log);
+    }
+    
+    // Also disconnect from current pending MAC
+    if (pendingMacRef.current && window.WebViewJavascriptBridge) {
+      log('Disconnecting from pending MAC:', pendingMacRef.current);
+      window.WebViewJavascriptBridge.callHandler('disconnectBle', pendingMacRef.current, () => {});
+    }
+    
+    // Update state
+    setServiceState(prev => ({
+      ...prev,
+      isReading: false,
+      error: error.message,
+    }));
+    
+    pendingServiceRef.current = null;
+    pendingMacRef.current = null;
+    
+    // Show toast and notify callback
+    if (error.requiresBluetoothReset) {
+      toast.error('Please turn Bluetooth OFF then ON and try again.');
+    } else {
+      toast.error(error.message);
+    }
+    
+    onErrorRef.current?.(error.message);
+    
+    return true; // Error was handled
+  }, [clearReadTimeout, log]);
+
+  // ============================================
   // CORE OPERATIONS
   // ============================================
 
@@ -114,7 +170,6 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
     log('Reading service:', serviceName, 'from:', macAddress);
     
     clearReadTimeout();
-    refreshRetryRef.current = 0;
     pendingServiceRef.current = serviceName;
     pendingMacRef.current = macAddress;
     
@@ -134,94 +189,31 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
         error: 'Service read timed out',
       }));
       
+      pendingServiceRef.current = null;
+      pendingMacRef.current = null;
+      
       toast.error('Could not read device data. Please try again.');
       onErrorRef.current?.('Service read timeout');
     }, SERVICE_READ_TIMEOUT);
 
     // Request service data
     // IMPORTANT: Handle synchronous error responses from native layer
-    // The native layer may return errors like {"respCode":"8","respDesc":"Bluetooth device not connected"}
-    // directly in the callback, rather than through the async bridge handlers
+    // The native layer may return errors directly in this callback,
+    // rather than through the async bridge handlers
     initServiceBleData(
       { serviceName, macAddress },
       (responseData: string) => {
         log('Service request response:', responseData);
         
-        // Check for synchronous error response from native layer
+        // Use centralized error handling for synchronous responses
         if (responseData) {
-          try {
-            const parsed = typeof responseData === 'string' ? JSON.parse(responseData) : responseData;
-            const respCode = parsed?.respCode || parsed?.responseData?.respCode;
-            const respDesc = parsed?.respDesc || parsed?.responseData?.respDesc || '';
-            
-            // respCode 8 = "Bluetooth device not connected"
-            // respCode 7 = MAC address mismatch
-            // Any non-200 respCode with respData=false indicates immediate error
-            if (respCode && respCode !== '200' && respCode !== 200 && parsed?.respData === false) {
-              log('Synchronous error from native layer:', { respCode, respDesc });
-              
-              clearReadTimeout();
-              
-              const isDisconnected = typeof respDesc === 'string' && (
-                respDesc.toLowerCase().includes('bluetooth device not connected') ||
-                respDesc.toLowerCase().includes('device not connected') ||
-                respDesc.toLowerCase().includes('not connected')
-              );
-              
-              const isMacMismatch = respCode === '7' || respCode === 7 || (
-                typeof respDesc === 'string' && (
-                  respDesc.toLowerCase().includes('macaddress is not match') ||
-                  respDesc.toLowerCase().includes('mac address is not match')
-                )
-              );
-              
-              if (isDisconnected || isMacMismatch) {
-                // Force disconnect from known MACs to clear native state
-                const connectedMac = sessionStorage.getItem('connectedDeviceMac');
-                const pendingStoredMac = sessionStorage.getItem('pendingBleMac');
-                
-                if (window.WebViewJavascriptBridge) {
-                  if (connectedMac) {
-                    log('Force disconnecting from connectedMac:', connectedMac);
-                    window.WebViewJavascriptBridge.callHandler('disconnectBle', connectedMac, () => {});
-                  }
-                  if (pendingStoredMac && pendingStoredMac !== connectedMac) {
-                    log('Force disconnecting from pendingMac:', pendingStoredMac);
-                    window.WebViewJavascriptBridge.callHandler('disconnectBle', pendingStoredMac, () => {});
-                  }
-                }
-                
-                // Clear sessionStorage
-                sessionStorage.removeItem('connectedDeviceMac');
-                sessionStorage.removeItem('pendingBleMac');
-                
-                const errorMessage = isMacMismatch
-                  ? 'Bluetooth connection stuck. Please turn Bluetooth OFF then ON.'
-                  : 'Bluetooth device not connected';
-                
-                setServiceState(prev => ({
-                  ...prev,
-                  isReading: false,
-                  error: errorMessage,
-                }));
-                
-                pendingServiceRef.current = null;
-                pendingMacRef.current = null;
-                
-                toast.error('Please turn Bluetooth OFF then ON and try again.');
-                onErrorRef.current?.(errorMessage);
-              }
-            }
-          } catch {
-            // Not JSON or parse error - this is normal for success cases
-            log('Service request acknowledged (non-JSON response)');
-          }
+          handleBleError(responseData, 'sync-callback');
         }
       }
     );
 
     return true;
-  }, [clearReadTimeout, log]);
+  }, [clearReadTimeout, handleBleError, log]);
 
   /**
    * Shortcut to read DTA service (common for batteries - energy data)
@@ -243,7 +235,6 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
   const cancelRead = useCallback(() => {
     log('Cancelling service read');
     clearReadTimeout();
-    refreshRetryRef.current = 0;
     pendingServiceRef.current = null;
     pendingMacRef.current = null;
     toast.dismiss('service-refresh');
@@ -255,7 +246,6 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
    */
   const resetState = useCallback(() => {
     clearReadTimeout();
-    refreshRetryRef.current = 0;
     pendingServiceRef.current = null;
     pendingMacRef.current = null;
     toast.dismiss('service-refresh');
@@ -309,73 +299,47 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
       window.WebViewJavascriptBridge.registerHandler(
         'bleInitServiceDataOnCompleteCallBack',
         (data: string, resp: (r: unknown) => void) => {
-          try {
-            const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+          // Use centralized error handling
+          const result = parseBleResponse(data);
+          
+          if (!result.success) {
+            // Handle error using centralized handler
+            const error = result.error!;
+            log('Service returned error (complete callback):', getDebugMessage(error));
             
-            // Check for error response
-            const respCode = parsedData?.respCode || parsedData?.responseData?.respCode;
-            const respDesc = parsedData?.respDesc || parsedData?.responseData?.respDesc || '';
+            clearReadTimeout();
+            toast.dismiss('service-refresh');
             
-            if (respCode && respCode !== '200' && respCode !== 200) {
-              log('Service returned error:', { respCode, respDesc });
-              
-              const isDisconnected = typeof respDesc === 'string' && (
-                respDesc.toLowerCase().includes('bluetooth device not connected') ||
-                respDesc.toLowerCase().includes('device not connected') ||
-                respDesc.toLowerCase().includes('not connected')
-              );
-              
-              // Check for MAC address mismatch error (respCode 7)
-              const isMacMismatch = respCode === '7' || respCode === 7 || (
-                typeof respDesc === 'string' && (
-                  respDesc.toLowerCase().includes('macaddress is not match') ||
-                  respDesc.toLowerCase().includes('mac address is not match') ||
-                  respDesc.toLowerCase().includes('macaddress not match')
-                )
-              );
-              
-              if (isDisconnected || isMacMismatch) {
-                clearReadTimeout();
-                toast.dismiss('service-refresh');
-                
-                // Force disconnect from ALL known MACs to clear native layer state
-                const connectedMac = sessionStorage.getItem('connectedDeviceMac');
-                const pendingMac = sessionStorage.getItem('pendingBleMac');
-                
-                if (window.WebViewJavascriptBridge) {
-                  if (connectedMac) {
-                    log('Force disconnecting from connectedMac:', connectedMac);
-                    window.WebViewJavascriptBridge.callHandler('disconnectBle', connectedMac, () => {});
-                  }
-                  if (pendingMac && pendingMac !== connectedMac) {
-                    log('Force disconnecting from pendingMac:', pendingMac);
-                    window.WebViewJavascriptBridge.callHandler('disconnectBle', pendingMac, () => {});
-                  }
-                }
-                
-                // Clear sessionStorage
-                sessionStorage.removeItem('connectedDeviceMac');
-                sessionStorage.removeItem('pendingBleMac');
-                
-                const errorMessage = isMacMismatch 
-                  ? 'Bluetooth connection stuck. Please turn Bluetooth OFF then ON.'
-                  : 'Bluetooth connection lost';
-                
-                setServiceState(prev => ({
-                  ...prev,
-                  isReading: false,
-                  error: errorMessage,
-                }));
-                
-                toast.error('Please turn Bluetooth OFF then ON and try again.');
-                onErrorRef.current?.(errorMessage);
-                resp({ success: false, error: respDesc });
-                return;
-              }
+            if (error.requiresBluetoothReset) {
+              forceDisconnectAll(log);
             }
             
+            setServiceState(prev => ({
+              ...prev,
+              isReading: false,
+              error: error.message,
+            }));
+            
+            pendingServiceRef.current = null;
+            pendingMacRef.current = null;
+            
+            if (error.requiresBluetoothReset) {
+              toast.error('Please turn Bluetooth OFF then ON and try again.');
+            } else {
+              toast.error(error.message);
+            }
+            
+            onErrorRef.current?.(error.message);
+            resp({ success: false, error: error.respDesc });
+            return;
+          }
+          
+          // Success case
+          try {
+            const parsedData = result.data as Record<string, unknown>;
+            
             // Get service name from response
-            const serviceName = parsedData?.serviceNameEnum || pendingServiceRef.current || 'unknown';
+            const serviceName = (parsedData?.serviceNameEnum as string) || pendingServiceRef.current || 'unknown';
             
             log('Service data received:', serviceName);
             clearReadTimeout();
@@ -393,21 +357,23 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
             onServiceDataRef.current?.(serviceName, parsedData);
             
             // Reset pending refs
-            refreshRetryRef.current = 0;
             pendingServiceRef.current = null;
             pendingMacRef.current = null;
             
             resp(parsedData);
           } catch (err) {
-            log('Error parsing service data:', err);
+            log('Error processing service data:', err);
             clearReadTimeout();
             toast.dismiss('service-refresh');
             
             setServiceState(prev => ({
               ...prev,
               isReading: false,
-              error: 'Failed to parse service data',
+              error: 'Failed to process service data',
             }));
+            
+            pendingServiceRef.current = null;
+            pendingMacRef.current = null;
             
             toast.error('Failed to read device data.');
             onErrorRef.current?.('Parse error');
@@ -420,70 +386,26 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
       window.WebViewJavascriptBridge.registerHandler(
         'bleInitServiceDataFailureCallBack',
         (data: string, resp: (r: unknown) => void) => {
-          log('Service read failed:', data);
+          log('Service read failed (failure callback):', data);
+          
+          // Use centralized error handling
+          const result = parseBleResponse(data);
+          const error = result.error;
           
           clearReadTimeout();
           toast.dismiss('service-refresh');
           
-          let errorMessage = 'Failed to read service data';
-          let requiresReset = false;
+          // Always force disconnect on failure callback
+          forceDisconnectAll(log);
           
-          const checkForDisconnect = (str: string) => {
-            return str.toLowerCase().includes('bluetooth device not connected') ||
-                   str.toLowerCase().includes('device not connected') ||
-                   str.toLowerCase().includes('not connected');
-          };
-          
-          const checkForMacMismatch = (str: string) => {
-            return str.toLowerCase().includes('macaddress is not match') ||
-                   str.toLowerCase().includes('mac address is not match') ||
-                   str.toLowerCase().includes('macaddress not match');
-          };
-          
-          try {
-            const parsed = JSON.parse(data);
-            const respDesc = parsed?.responseData?.respDesc || parsed?.respDesc || '';
-            const respCode = parsed?.responseData?.respCode || parsed?.respCode || '';
-            
-            if (checkForDisconnect(String(respDesc))) {
-              errorMessage = 'Bluetooth connection lost';
-              requiresReset = true;
-            } else if (checkForMacMismatch(String(respDesc)) || respCode === '7') {
-              errorMessage = 'Bluetooth connection stuck. Please turn Bluetooth OFF then ON.';
-              requiresReset = true;
-            }
-          } catch {
-            if (checkForDisconnect(data)) {
-              errorMessage = 'Bluetooth connection lost';
-              requiresReset = true;
-            } else if (checkForMacMismatch(data)) {
-              errorMessage = 'Bluetooth connection stuck. Please turn Bluetooth OFF then ON.';
-              requiresReset = true;
-            }
+          // Also disconnect from pending MAC
+          if (pendingMacRef.current && window.WebViewJavascriptBridge) {
+            log('Disconnecting from pending MAC:', pendingMacRef.current);
+            window.WebViewJavascriptBridge.callHandler('disconnectBle', pendingMacRef.current, () => {});
           }
           
-          // Force disconnect from ALL known MACs to clear native layer state
-          const connectedMac = sessionStorage.getItem('connectedDeviceMac');
-          const pendingStoredMac = sessionStorage.getItem('pendingBleMac');
-          
-          if (window.WebViewJavascriptBridge) {
-            if (connectedMac) {
-              log('Force disconnecting from connectedMac:', connectedMac);
-              window.WebViewJavascriptBridge.callHandler('disconnectBle', connectedMac, () => {});
-            }
-            if (pendingStoredMac && pendingStoredMac !== connectedMac) {
-              log('Force disconnecting from pendingMac:', pendingStoredMac);
-              window.WebViewJavascriptBridge.callHandler('disconnectBle', pendingStoredMac, () => {});
-            }
-            if (pendingMacRef.current && pendingMacRef.current !== connectedMac && pendingMacRef.current !== pendingStoredMac) {
-              log('Force disconnecting from pendingMacRef:', pendingMacRef.current);
-              window.WebViewJavascriptBridge.callHandler('disconnectBle', pendingMacRef.current, () => {});
-            }
-          }
-          
-          // Clear sessionStorage
-          sessionStorage.removeItem('connectedDeviceMac');
-          sessionStorage.removeItem('pendingBleMac');
+          const errorMessage = error?.message || 'Failed to read service data';
+          const requiresReset = error?.requiresBluetoothReset ?? true; // Default to true for failure callback
           
           setServiceState(prev => ({
             ...prev,
@@ -491,7 +413,6 @@ export function useBleServiceReader(options: UseBleServiceReaderOptions = {}) {
             error: errorMessage,
           }));
           
-          refreshRetryRef.current = 0;
           pendingServiceRef.current = null;
           pendingMacRef.current = null;
           

--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -451,7 +451,7 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
           setDtaData(null);
           isProcessingRef.current = false;
         } else {
-          log('Failed to extract energy data from DTA');
+          log('Failed to extract energy data from DTA - using consolidated cleanup');
           
           // Disconnect on failure
           if (connectedDevice) {
@@ -459,20 +459,15 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
           }
           
           toast.error('Could not read battery data. Please try again.');
+          
+          // Notify error callback before cleanup
           onErrorRef.current?.('Failed to extract energy data from DTA');
           
-          // Clear pending state
-          setPendingBatteryId(null);
-          setPendingScanType(null);
-          setReadingPhase('idle');
-          setDtaData(null);
-          isProcessingRef.current = false;
+          // Use consolidated cleanup - this ensures modal closes properly
+          // by setting forceClosedRef and resetting all state
+          cleanupAllBleState(true);
           
-          setState(prev => ({
-            ...prev,
-            error: 'Failed to read battery data',
-            connectionFailed: true,
-          }));
+          log('DTA extraction failure handled via cleanupAllBleState');
         }
       }
     }
@@ -485,6 +480,7 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
     dtaData,
     readDtaService,
     connectionDisconnect,
+    cleanupAllBleState,
     log,
   ]);
 

--- a/src/lib/hooks/ble/useFlowBatteryScan.ts
+++ b/src/lib/hooks/ble/useFlowBatteryScan.ts
@@ -515,9 +515,12 @@ export function useFlowBatteryScan(options: UseFlowBatteryScanOptions = {}) {
       log('Service read failed/timed out during', readingPhase, '- Error:', serviceState.error);
       
       // Notify error callback before cleanup
+      // Check for errors that require Bluetooth reset (toggle off/on)
       const requiresReset = serviceState.error.toLowerCase().includes('toggle bluetooth') ||
                            serviceState.error.toLowerCase().includes('bluetooth off') ||
-                           serviceState.error.toLowerCase().includes('connection stuck');
+                           serviceState.error.toLowerCase().includes('connection stuck') ||
+                           serviceState.error.toLowerCase().includes('device not connected') ||
+                           serviceState.error.toLowerCase().includes('not connected');
       onErrorRef.current?.(serviceState.error, requiresReset);
       
       // Use consolidated cleanup - this handles everything


### PR DESCRIPTION
Call `cleanupAllBleState(true)` on DTA extraction failure to ensure the Progress Modal closes and all BLE state is properly reset.

Previously, manual cleanup in this specific error path was incomplete, failing to set `forceClosedRef.current` and reset `isReadingEnergy`. This caused the `BleProgressModal` to remain visible, as it relies on these states for its `isActive` condition.

---
<a href="https://cursor.com/background-agent?bcId=bc-b94df401-14c2-49ba-acd4-89bb03287499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b94df401-14c2-49ba-acd4-89bb03287499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

