### PR TITLE
Ble scanning message update

### DIFF
--- a/src/components/shared/BleDeviceList.tsx
+++ b/src/components/shared/BleDeviceList.tsx
@@ -324,6 +324,10 @@ export default function BleDeviceList({
                 {t('ble.tapRefreshToRestart') || 'Tap the ↻ icon above to restart scanning'}
               </span>
             )}
+            {/* Additional hint about toggling Bluetooth if rescanning doesn't work */}
+            <span className="ble-device-toggle-hint">
+              {t('ble.toggleBluetoothHint') || 'Still no devices? Try turning Bluetooth off and on again'}
+            </span>
           </div>
         )}
 
@@ -767,6 +771,14 @@ export default function BleDeviceList({
           background: ${colors.brand.primary}15;
           border-radius: ${radius.md};
           font-weight: ${fontWeight.medium};
+        }
+
+        .ble-device-toggle-hint {
+          display: block;
+          margin-top: ${spacing[2]};
+          font-size: ${fontSize.xs};
+          color: ${colors.text.muted};
+          font-style: italic;
         }
 
         .ble-device-skeleton {

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1225,6 +1225,7 @@
   "ble.noDevicesFound": "No devices found nearby",
   "ble.noDevicesHint": "Make sure the battery is powered on and Bluetooth is enabled",
   "ble.tapRefreshToRestart": "Tap the ↻ icon above to restart scanning",
+  "ble.toggleBluetoothHint": "Still no devices? Try turning Bluetooth off and on again",
   "ble.noMatchingDevices": "No devices match your search",
   "ble.rescan": "Rescan",
   "ble.stopScanning": "Stop scanning",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1216,6 +1216,7 @@
   "ble.noDevicesFound": "Aucun appareil trouvé à proximité",
   "ble.noDevicesHint": "Assurez-vous que la batterie est allumée et que le Bluetooth est activé",
   "ble.tapRefreshToRestart": "Appuyez sur l'icône ↻ ci-dessus pour relancer la recherche",
+  "ble.toggleBluetoothHint": "Toujours aucun appareil ? Essayez d'éteindre puis de rallumer le Bluetooth",
   "ble.noMatchingDevices": "Aucun appareil ne correspond à votre recherche",
   "ble.rescan": "Rescanner",
   "ble.stopScanning": "Arrêter la recherche",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1127,6 +1127,7 @@
   "ble.noDevicesFound": "附近未找到设备",
   "ble.noDevicesHint": "请确保电池已开启且蓝牙已启用",
   "ble.tapRefreshToRestart": "点击上方 ↻ 图标重新开始扫描",
+  "ble.toggleBluetoothHint": "仍然找不到设备？尝试关闭再打开蓝牙",
   "ble.noMatchingDevices": "没有匹配您搜索的设备",
   "ble.rescan": "重新扫描",
   "ble.stopScanning": "停止扫描",


### PR DESCRIPTION
Add a hint to the BLE scanning empty state to suggest toggling Bluetooth for an edge case where no devices are found after rescanning.

---
<a href="https://cursor.com/background-agent?bcId=bc-cbf4a54b-812f-45d4-be61-fce6dc3e33ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cbf4a54b-812f-45d4-be61-fce6dc3e33ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

