### PR TITLE
Battery verification logic failure

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1190,6 +1190,8 @@
   "attendant.connectionFailed": "Connection failed",
   "attendant.wrongBattery": "Wrong battery! This battery does not belong to the customer.",
   "attendant.batteryMismatch": "Battery does not belong to this customer",
+  "attendant.batteryIdMismatch": "Battery ID does not match customer record",
+  "attendant.wrongBatteryOpid": "Wrong battery! The battery ID read from the device does not match the customer's assigned battery.",
   "attendant.coveredByQuota": "Covered by quota",
   "attendant.toPay": "To pay",
   "attendant.returning": "Returning",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1181,6 +1181,8 @@
   "attendant.connectionFailed": "Échec de la connexion",
   "attendant.wrongBattery": "Mauvaise batterie ! Cette batterie n'appartient pas au client.",
   "attendant.batteryMismatch": "La batterie n'appartient pas à ce client",
+  "attendant.batteryIdMismatch": "L'ID de la batterie ne correspond pas au dossier du client",
+  "attendant.wrongBatteryOpid": "Mauvaise batterie ! L'ID de batterie lu depuis l'appareil ne correspond pas à la batterie assignée au client.",
   "attendant.coveredByQuota": "Couvert par le quota",
   "attendant.toPay": "À payer",
   "attendant.returning": "Retour",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1092,6 +1092,8 @@
   "attendant.connectionFailed": "连接失败",
   "attendant.wrongBattery": "错误的电池！此电池不属于该客户。",
   "attendant.batteryMismatch": "电池不属于此客户",
+  "attendant.batteryIdMismatch": "电池ID与客户记录不匹配",
+  "attendant.wrongBatteryOpid": "错误的电池！从设备读取的电池ID与客户分配的电池不匹配。",
   "attendant.coveredByQuota": "配额已覆盖",
   "attendant.toPay": "需支付",
   "attendant.returning": "归还",


### PR DESCRIPTION
Strengthen battery verification's second line of defense by removing the permissive last-6-chars ID matching.

The second line of defense for battery verification (using actual OPID/PPID from the device) was failing. It incorrectly allowed batteries to pass if only their last 6 characters matched the `current_asset` ID, even if the full IDs were different. This fix removes the permissive last-6-chars fallback, ensuring a stricter comparison and preventing different batteries from being accepted due to a coincidental suffix match.

---
<a href="https://cursor.com/background-agent?bcId=bc-ed9024a0-728f-49a4-93dc-a2e72f5b4be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed9024a0-728f-49a4-93dc-a2e72f5b4be7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

