### PR TITLE
Attendant review quota display

### DIFF
--- a/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
+++ b/src/app/(mobile)/attendant/attendant/components/steps/Step4Review.tsx
@@ -21,6 +21,12 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
   
   // Should skip payment: either has sufficient quota OR rounded cost is zero
   const shouldSkipPayment = hasSufficientQuota || isZeroCost;
+  
+  // Determine why payment is being skipped (for display purposes)
+  // - isQuotaBased: Customer has available quota that will be deducted (NOT free - quota is used)
+  // - isZeroCostOnly: Actual cost is zero or negative (genuinely no charge)
+  const isQuotaBased = hasSufficientQuota;
+  const isZeroCostOnly = !hasSufficientQuota && isZeroCost;
 
   // Calculate values
   const oldBatteryKwh = (swapData.oldBattery?.energy || 0) / 1000;
@@ -55,15 +61,24 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
           <div className="review-customer-info">
             <span className="review-customer-name">{customerData?.name || 'Customer'}</span>
             <span className="review-label">
-              {shouldSkipPayment 
-                ? (t('attendant.noPaymentNeeded') || 'No Payment Needed')
-                : (t('attendant.customerPays') || 'Amount Due')}
+              {isQuotaBased 
+                ? (t('attendant.quotaAvailable') || 'Quota Available')
+                : isZeroCostOnly
+                  ? (t('attendant.noPaymentNeeded') || 'No Payment Needed')
+                  : (t('attendant.customerPays') || 'Amount Due')}
             </span>
           </div>
         </div>
         
         <div className={`review-amount ${shouldSkipPayment ? 'free' : ''}`}>
-          {shouldSkipPayment ? (
+          {isQuotaBased ? (
+            <>
+              <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
+                <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>
+              </svg>
+              <span>{t('attendant.usingQuota') || 'Using Quota'}</span>
+            </>
+          ) : isZeroCostOnly ? (
             <>
               <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
                 <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>
@@ -176,12 +191,21 @@ export default function Step4Review({ swapData, customerData, hasSufficientQuota
         {/* Step 3: Balance / Final amount */}
         <div className="summary-row total">
           <span className="calc-label">
-            {shouldSkipPayment 
-              ? (t('attendant.balance') || 'Balance')
-              : (t('attendant.amountToPay') || 'Amount to pay')}
+            {isQuotaBased
+              ? (t('attendant.coveredByQuotaLabel') || 'Covered by Quota')
+              : shouldSkipPayment 
+                ? (t('attendant.balance') || 'Balance')
+                : (t('attendant.amountToPay') || 'Amount to pay')}
           </span>
           <span className={`calc-total ${shouldSkipPayment ? 'free' : ''}`}>
-            {shouldSkipPayment ? (
+            {isQuotaBased ? (
+              <>
+                <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
+                  <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>
+                </svg>
+                {t('attendant.quotaApplied') || 'Quota Applied'}
+              </>
+            ) : isZeroCostOnly ? (
               <>
                 <svg viewBox="0 0 24 24" fill="currentColor" width="14" height="14">
                   <path d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"/>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -1150,6 +1150,9 @@
   "attendant.proceedToPayment": "Collect Payment",
   
   "attendant.quotaCreditAvailable": "Quota Credit Available",
+  "attendant.quotaAvailable": "Quota Available",
+  "attendant.usingQuota": "Using Quota",
+  "attendant.coveredByQuotaLabel": "Covered by Quota",
   "attendant.noPaymentRequired": "No payment required - using existing credit",
   "attendant.zeroCostSwap": "Zero Cost Swap",
   "attendant.noPaymentRequiredZeroCost": "No payment required - zero total cost",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -1141,6 +1141,9 @@
   "attendant.proceedToPayment": "Encaisser",
   
   "attendant.quotaCreditAvailable": "Crédit de quota disponible",
+  "attendant.quotaAvailable": "Quota Disponible",
+  "attendant.usingQuota": "Utilisation du Quota",
+  "attendant.coveredByQuotaLabel": "Couvert par le Quota",
   "attendant.noPaymentRequired": "Aucun paiement requis - utilisation du crédit existant",
   "attendant.zeroCostSwap": "Échange sans frais",
   "attendant.noPaymentRequiredZeroCost": "Aucun paiement requis - coût total zéro",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -1052,6 +1052,9 @@
   "attendant.proceedToPayment": "收款",
   
   "attendant.quotaCreditAvailable": "可用配额余额",
+  "attendant.quotaAvailable": "配额可用",
+  "attendant.usingQuota": "使用配额",
+  "attendant.coveredByQuotaLabel": "配额已覆盖",
   "attendant.noPaymentRequired": "无需支付 - 使用现有额度",
   "attendant.zeroCostSwap": "零费用更换",
   "attendant.noPaymentRequiredZeroCost": "无需支付 - 总费用为零",


### PR DESCRIPTION
Update Attendant flow review page to clarify when a service is covered by quota versus genuinely free.

The previous implementation displayed "FREE" when a customer had available quota, which was inaccurate as quota is deducted on the backend. This change introduces distinct messaging to indicate that quota is being utilized, reserving "FREE" for truly zero-cost services.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca6c712a-71cd-4399-80ed-20e25d41db42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ca6c712a-71cd-4399-80ed-20e25d41db42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

