### PR TITLE
Attendant session banner issue

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -214,6 +214,8 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
   });
   
   // Check for pending session on mount
+  // Note: We always call checkSession() immediately - the hook handles auth verification
+  // internally via getEmployeeToken(). This avoids race conditions with attendantInfo state.
   useEffect(() => {
     const checkSession = async () => {
       const hasPending = await checkForPendingSession();
@@ -223,13 +225,8 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
       setSessionCheckComplete(true);
     };
     
-    // Only check if we have auth token
-    if (attendantInfo.id !== 'attendant-001') {
-      checkSession();
-    } else {
-      setSessionCheckComplete(true);
-    }
-  }, [attendantInfo.id, checkForPendingSession]);
+    checkSession();
+  }, [checkForPendingSession]);
   
   // Handle session resume
   const handleResumeSession = useCallback(async () => {


### PR DESCRIPTION
Remove a conditional check that caused a race condition, preventing the session resume banner from appearing.

The `useEffect` responsible for checking pending sessions was guarded by `if (attendantInfo.id !== 'attendant-001')`. On initial render, `attendantInfo.id` was often `'attendant-001'` (its default), causing the session check to be skipped. The `useWorkflowSession` hook already handles authentication internally by checking `getEmployeeToken()` directly, making the `attendantInfo.id` check unnecessary and prone to race conditions.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1016dff-e247-4f27-b97c-b12351a8a696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1016dff-e247-4f27-b97c-b12351a8a696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

