### PR TITLE
Session resume logic error

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -758,9 +758,12 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
       return;
     }
     
-    // Don't save on step 6 (success) - session is complete
+    // When reaching step 6 (success), the workflow is complete - clear the session
+    // This prevents the completed session from appearing as "pending" on next app open
     if (currentStep === 6) {
+      console.info('[AttendantFlow] Workflow completed (step 6) - clearing session');
       prevStepRef.current = currentStep;
+      clearSession();
       return;
     }
     
@@ -769,7 +772,7 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
     
     // Save session with current state
     saveSessionData(currentStep, maxStepReached);
-  }, [currentStep, maxStepReached, sessionOrderId, saveSessionData]);
+  }, [currentStep, maxStepReached, sessionOrderId, saveSessionData, clearSession]);
 
   // Start QR code scan using native bridge (follows existing pattern from swap.tsx)
   const startQrCodeScan = useCallback(() => {

--- a/src/lib/hooks/useWorkflowSession.ts
+++ b/src/lib/hooks/useWorkflowSession.ts
@@ -165,6 +165,20 @@ export function useWorkflowSession(config: UseWorkflowSessionConfig): UseWorkflo
           return false;
         }
         
+        // Check if the session is "effectively complete" and should not be resumed
+        // This handles edge cases where the session was saved just before completion
+        // (e.g., user was at Review step, clicked "Proceed", and app closed before MQTT response)
+        if (isSessionEffectivelyComplete(sessionDataFromServer, workflowType)) {
+          console.info('[useWorkflowSession] Found pending session but it appears effectively complete - ignoring:', {
+            currentStep: sessionDataFromServer?.currentStep,
+            maxStepReached: sessionDataFromServer?.maxStepReached,
+            hasSwapData: !!(sessionDataFromServer?.swapData?.oldBattery && sessionDataFromServer?.swapData?.newBattery),
+            cost: sessionDataFromServer?.swapData?.cost,
+          });
+          setStatus('idle');
+          return false;
+        }
+        
         // Build session summary for UI
         const summary: SessionSummary = {
           orderId: response.order.id,
@@ -449,6 +463,77 @@ export function useWorkflowSession(config: UseWorkflowSessionConfig): UseWorkflo
 // ============================================================================
 // Helper Functions
 // ============================================================================
+
+/**
+ * Check if a session is "effectively complete" and should not be resumed
+ * 
+ * This handles edge cases where:
+ * 1. User was at the Review step (step 4) and clicked "Proceed"
+ * 2. The swap was quota-based (cost <= 0) so payment was skipped
+ * 3. The MQTT publish was triggered but app closed before response
+ * 4. Session remains at step 4 but the swap may have already been recorded
+ * 
+ * In such cases, resuming could lead to duplicate swaps or confusing UX.
+ * We consider a session "effectively complete" if:
+ * - Attendant workflow at step 4+ with both batteries scanned and cost <= 0
+ * - Attendant workflow at step 5+ (payment phase or later)
+ * - SalesPerson workflow at the final registration step
+ */
+function isSessionEffectivelyComplete(
+  sessionData: WorkflowSessionData | undefined,
+  workflowType: 'attendant' | 'salesperson'
+): boolean {
+  if (!sessionData) return false;
+  
+  const currentStep = sessionData.currentStep || 1;
+  const maxStepReached = sessionData.maxStepReached || 1;
+  
+  if (workflowType === 'attendant') {
+    // For attendant workflow:
+    // - Steps 1-3: Customer/Battery scanning - safe to resume
+    // - Step 4 (Review): 
+    //   - If cost <= 0 and both batteries present, likely completed without payment
+    //   - If cost > 0, might be waiting for payment - could resume
+    // - Step 5+ (Payment/Success): Already in final phase
+    
+    const swapData = sessionData.swapData;
+    const hasBothBatteries = !!(swapData?.oldBattery && swapData?.newBattery);
+    const cost = swapData?.cost ?? 0;
+    const chargeableEnergy = swapData?.chargeableEnergy ?? 0;
+    
+    // Step 5 or higher - already past the point of no return
+    if (currentStep >= 5 || maxStepReached >= 5) {
+      return true;
+    }
+    
+    // Step 4 with both batteries and no payment needed (quota-based or zero cost)
+    // This is the case where user clicked "Proceed" and skipPayment was called
+    if (currentStep === 4 && maxStepReached === 4 && hasBothBatteries) {
+      // Cost is 0 or negative means no payment was required
+      if (cost <= 0) {
+        return true;
+      }
+      
+      // Chargeable energy is 0 or negative means quota covered everything
+      if (chargeableEnergy <= 0) {
+        return true;
+      }
+    }
+    
+    return false;
+  }
+  
+  // For salesperson workflow, similar logic could be added if needed
+  // For now, just check if at the final step
+  if (workflowType === 'salesperson') {
+    // Step 7 is the success step for salesperson
+    if (currentStep >= 7 || maxStepReached >= 7) {
+      return true;
+    }
+  }
+  
+  return false;
+}
 
 /**
  * Format timestamp for display

--- a/src/lib/hooks/useWorkflowSession.ts
+++ b/src/lib/hooks/useWorkflowSession.ts
@@ -482,7 +482,7 @@ export function useWorkflowSession(config: UseWorkflowSessionConfig): UseWorkflo
  * - SalesPerson workflow at the final registration step
  */
 function isSessionEffectivelyComplete(
-  sessionData: WorkflowSessionData | undefined,
+  sessionData: WorkflowSessionData | null | undefined,
   workflowType: 'attendant' | 'salesperson'
 ): boolean {
   if (!sessionData) return false;


### PR DESCRIPTION
Clear attendant workflow sessions upon completion and prevent resuming sessions that are effectively complete.

Previously, sessions that completed (especially quota-based ones) were not explicitly cleared when reaching the success step (step 6). The auto-save skipped saving at step 6, but the session remained `in_progress` at step 4, leading to users being prompted to resume an already finished swap. This PR ensures sessions are cleared on success and adds a check to prevent resuming sessions that are "effectively complete" (e.g., at step 4 with both batteries scanned and zero cost).

---
<a href="https://cursor.com/background-agent?bcId=bc-3eff3f7f-bb36-4dff-abe1-5a2ebdd1d7d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3eff3f7f-bb36-4dff-abe1-5a2ebdd1d7d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

