### PR TITLE
Attendant workflow scan button

### DIFF
--- a/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
+++ b/src/app/(mobile)/attendant/attendant/AttendantFlow.tsx
@@ -1843,17 +1843,19 @@ export default function AttendantFlow({ onBack, onLogout }: AttendantFlowProps) 
         {renderStepContent()}
       </main>
 
-      {/* Action Bar */}
-      <ActionBar
-        currentStep={currentStep}
-        onBack={handleBack}
-        onMainAction={handleMainAction}
-        isLoading={isScanning || isProcessing || isPaymentProcessing || paymentAndServiceStatus === 'pending'}
-        inputMode={inputMode}
-        paymentInputMode={paymentInputMode}
-        hasSufficientQuota={hasSufficientQuota}
-        swapCost={swapData.cost}
-      />
+      {/* Action Bar - Only show after session check is complete */}
+      {sessionCheckComplete && (
+        <ActionBar
+          currentStep={currentStep}
+          onBack={handleBack}
+          onMainAction={handleMainAction}
+          isLoading={isScanning || isProcessing || isPaymentProcessing || paymentAndServiceStatus === 'pending'}
+          inputMode={inputMode}
+          paymentInputMode={paymentInputMode}
+          hasSufficientQuota={hasSufficientQuota}
+          swapCost={swapData.cost}
+        />
+      )}
 
       {/* Loading Overlay - Simple overlay for non-BLE operations */}
       {(isScanning || isProcessing || isPaymentProcessing || paymentAndServiceStatus === 'pending') && 


### PR DESCRIPTION
Conditionally render the `ActionBar` in the Attendant Workflow to prevent the "Scan battery" button from appearing before session check completion.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b4882b7-921c-464a-936c-e5879936a274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b4882b7-921c-464a-936c-e5879936a274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

