### PR TITLE
Graphql input type correction

### DIFF
--- a/src/lib/graphql/mutations.ts
+++ b/src/lib/graphql/mutations.ts
@@ -138,7 +138,7 @@ export interface IdentifyCustomerResponse {
  * GraphQL mutation for identifying a customer by QR code or subscription ID
  */
 export const IDENTIFY_CUSTOMER = gql`
-  mutation IdentifyCustomer($input: IdentifyCustomerInput!) {
+  mutation IdentifyCustomer($input: BssIdentifyCustomerInput!) {
     identifyCustomer(input: $input) {
       customer_identified
       identification_method
@@ -216,7 +216,7 @@ export interface ReportPaymentAndServiceResponse {
  * GraphQL mutation for reporting both payment and service completion
  */
 export const REPORT_PAYMENT_AND_SERVICE = gql`
-  mutation ReportPaymentAndService($input: ReportPaymentAndServiceInput!) {
+  mutation ReportPaymentAndService($input: BssReportPaymentAndServiceInput!) {
     reportPaymentAndServiceCompletion(input: $input) {
       payment_processed
       service_completed


### PR DESCRIPTION
Fix GraphQL `IdentifyCustomer` and `ReportPaymentAndService` mutations to use `Bss` prefixed input types.

The previous mutations used incorrect input type names (`IdentifyCustomerInput`, `ReportPaymentAndServiceInput`), leading to `GRAPHQL_VALIDATION_FAILED` errors because the backend expects `BssIdentifyCustomerInput` and `BssReportPaymentAndServiceInput`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4007280e-024e-4918-9178-f53a39cb875a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4007280e-024e-4918-9178-f53a39cb875a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

