### PR TITLE
Salesperson package fetch issue

### DIFF
--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -139,6 +139,7 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
   const [formErrors, setFormErrors] = useState<Partial<Record<keyof CustomerFormData, string>>>({});
 
   // Product catalog hook - fetches products, packages, and plans from Odoo
+  // Using workflowType: 'sales' to ensure we use the correct sales role token
   const {
     products: availableProducts,
     packages: availablePackages,
@@ -155,7 +156,7 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
     setSelectedPlanId,
     refetch: fetchProductsAndPlans,
     restoreSelections: restoreCatalogSelections,
-  } = useProductCatalog({ autoFetch: true });
+  } = useProductCatalog({ autoFetch: true, workflowType: 'sales' });
 
   // Alias loading/error states for backward compatibility
   const isLoadingProducts = catalogLoading.products;


### PR DESCRIPTION
Update `useProductCatalog` to directly use `getSalesRoleToken` for sales workflows, fixing package fetching issues after session management changes.

The `getEmployeeToken()` function, previously used by `useProductCatalog`, was designed for a unified token system. With the recent separation of Attendant and Sales sessions, this function was not reliably providing the correct `SALES_ACCESS_TOKEN` for the salesperson flow, leading to packages failing to load. By introducing a `workflowType` parameter, the hook now explicitly requests the `sales` token when in the sales context, bypassing the problematic legacy token retrieval logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-b178243c-2f23-4f10-acdb-54ae8199ecb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b178243c-2f23-4f10-acdb-54ae8199ecb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

