### PR TITLE
Payment endpoint and session

### DIFF
--- a/src/lib/hooks/useWorkflowSession.ts
+++ b/src/lib/hooks/useWorkflowSession.ts
@@ -654,11 +654,10 @@ function isSessionEffectivelyComplete(
     return false;
   }
   
-  // For salesperson workflow, similar logic could be added if needed
-  // For now, just check if at the final step
+  // For salesperson workflow, Step 8 is the success/completion step
   if (workflowType === 'salesperson') {
-    // Step 7 is the success step for salesperson
-    if (currentStep >= 7 || maxStepReached >= 7) {
+    // Step 8 is the success step for salesperson
+    if (currentStep >= 8 || maxStepReached >= 8) {
       return true;
     }
   }


### PR DESCRIPTION
Remove legacy `localStorage` session management and fix payment initiation logic to align with session-based workflow.

This PR resolves two main issues:
1.  **Double Session Modals**: The application was showing two session resume modals because it was checking both backend sessions and legacy `localStorage` sessions. `localStorage` session management has been removed entirely.
2.  **Payment Endpoint Error**: The payment initiation incorrectly required a `subscriptionCode` upfront, causing 'No Subscription created' errors when using the session-based `PUT /api/sessions/by-order/{order_id}` endpoint. The payment logic now primarily uses `order_id` and makes the STK push conditional on `subscriptionCode` availability, allowing the session-based flow to proceed.
Additionally, the sales workflow step count in `useWorkflowSession` was corrected from 7 to 8.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b3aaa2e-2899-4e19-bda0-db8513c84463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b3aaa2e-2899-4e19-bda0-db8513c84463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

