### PR TITLE
Salesperson workflow pricing

### DIFF
--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -1543,6 +1543,34 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
     toast('Ready to scan a new battery');
   }, [hookResetState, bleIsReady, startBleScan]);
 
+  // Handle manual identification retry - wrapper that handles both:
+  // 1. Normal retry (when identification was previously attempted)
+  // 2. Fresh identification (when identification was never started, e.g., session restore)
+  const handleManualIdentify = useCallback(() => {
+    // Get the subscription code
+    const subscriptionId = confirmedSubscriptionCode || subscriptionData?.subscriptionCode;
+    
+    if (!subscriptionId) {
+      toast.error('No subscription found. Please complete payment first.');
+      return;
+    }
+    
+    // If identification was previously attempted (status is 'failed' or has lastError),
+    // the manualRetry function will work. Otherwise, we need to trigger fresh identification.
+    if (identificationStatus === 'idle' || identificationStatus === 'pending' || identificationStatus === 'retrying') {
+      // Fresh identification - never started or still in progress
+      console.info('[SALES] Triggering fresh customer identification:', subscriptionId);
+      identifyCustomer({
+        subscriptionCode: subscriptionId,
+        source: 'manual',
+      });
+    } else {
+      // Retry - identification was attempted before (failed or success)
+      console.info('[SALES] Retrying customer identification:', subscriptionId);
+      manualIdentifyCustomer();
+    }
+  }, [confirmedSubscriptionCode, subscriptionData?.subscriptionCode, identificationStatus, identifyCustomer, manualIdentifyCustomer]);
+
   // Handle service completion - uses customer identification + payment and service hooks
   // This is for first-time customer purchase (new subscription)
   // 
@@ -2025,7 +2053,7 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
             customerIdentified={customerIdentified}
             isIdentifying={isIdentifying}
             identificationFailed={identificationFailed}
-            onManualIdentify={manualIdentifyCustomer}
+            onManualIdentify={handleManualIdentify}
           />
         );
       case 8:

--- a/src/app/(mobile)/customers/customerform/components/steps/Step4AssignBattery.tsx
+++ b/src/app/(mobile)/customers/customerform/components/steps/Step4AssignBattery.tsx
@@ -137,7 +137,12 @@ export default function Step4AssignBattery({
         />
 
         {/* Identification Status / First-Time Customer Discount Card */}
-        {identificationFailed ? (
+        {/* Show failed/retry card when:
+            1. Identification explicitly failed (all retries exhausted), OR
+            2. Identification was never started AND we don't have pricing AND not currently identifying
+            This prevents the "loading pricing..." spinner from showing indefinitely when identification
+            wasn't triggered (e.g., session restore) or failed silently */}
+        {identificationFailed || (!isIdentifying && !customerIdentified && rate === 0) ? (
           <IdentificationFailedCard onRetry={onManualIdentify} />
         ) : (
           <FirstTimeDiscountCard
@@ -145,7 +150,7 @@ export default function Step4AssignBattery({
             rate={rate}
             cost={calculatedCost}
             currencySymbol={currencySymbol || selectedPlan?.currencySymbol || 'KES'}
-            isLoading={isIdentifying || (!customerIdentified && rate === 0)}
+            isLoading={isIdentifying}
           />
         )}
 


### PR DESCRIPTION
Fixes infinite "Loading pricing..." on Battery Scanned page when customer identification fails or isn't triggered.

Previously, the UI would get stuck in a loading state if customer identification was never initiated (e.g., after a session restore) or failed silently, because the `identificationFailed` flag wasn't set to true. The updated logic now correctly displays a "Pricing unavailable" card with a retry option in these scenarios.

---
<a href="https://cursor.com/background-agent?bcId=bc-e903a60b-947a-460b-9ff4-7d2c1305f157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e903a60b-947a-460b-9ff4-7d2c1305f157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

