### PR TITLE
Order update subscription extraction

### DIFF
--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -1200,16 +1200,19 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
           registrationId: '',
         });
         
-        // Update session with products
-        const success = await updateSessionWithProducts(sessionData, products);
+        // Update session with products - returns subscription code from backend
+        const result = await updateSessionWithProducts(sessionData, products);
         
-        if (success) {
+        if (result.success) {
           // Update local state
           const totalPrice = currentSelectedPlan.price + currentSelectedPackage.price;
           
+          // Extract subscription code from response
+          const subscriptionCode = result.subscriptionCode || '';
+          
           setSubscriptionData({
-            id: 0, // Updated from backend later
-            subscriptionCode: '', // Updated from backend later
+            id: 0, // Will be populated after full subscription activation
+            subscriptionCode, // Now populated from session update response!
             status: 'pending',
             productName: currentSelectedPlan.name,
             priceAtSignup: totalPrice,
@@ -1221,10 +1224,13 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
           setPaymentAmountExpected(totalPrice);
           setPaymentAmountRemaining(totalPrice);
           
-          console.log('Products added to order via session update');
+          console.log('Products added to order via session update:', {
+            subscriptionCode,
+            subscriptionsCreated: result.subscriptionsCreated,
+          });
           
           return {
-            subscriptionCode: '', // Will be populated after payment
+            subscriptionCode, // Now available from session update response
             orderId: sessionOrderId,
           };
         } else {

--- a/src/lib/odoo-api.ts
+++ b/src/lib/odoo-api.ts
@@ -1293,6 +1293,15 @@ export interface UpdateSessionWithPaymentPayload {
 }
 
 /**
+ * Subscription created as part of a session update (when products are added)
+ */
+export interface CreatedSubscription {
+  subscription_code: string;
+  product_id: number;
+  product_name: string;
+}
+
+/**
  * Response from updating a session
  */
 export interface UpdateSessionResponse {
@@ -1302,16 +1311,24 @@ export interface UpdateSessionResponse {
     id: number;
     name: string;
     state: string;
+    sale_order_id?: number;
+    session_data?: Record<string, unknown>;
   };
   order?: {
     id: number;
     name: string;
     state: string;
     amount_total: number;
-    expected_amount: number;
-    paid_amount: number;
-    remaining_amount: number;
+    amount_untaxed?: number;
+    amount_tax?: number;
+    expected_amount?: number;
+    paid_amount?: number;
+    remaining_amount?: number;
   };
+  /** Subscription code returned when products are added to order */
+  subscription_code?: string;
+  /** Array of subscriptions created when products are added */
+  subscriptions_created?: CreatedSubscription[];
 }
 
 /**


### PR DESCRIPTION
Capture and use the `subscription_code` directly from the session update API response to align with backend changes.

The `PUT /api/orders/{orderId}` endpoint now returns the `subscription_code` and `subscriptions_created` fields when products are added to an order. This PR updates the frontend to immediately extract and utilize this information in the Sales workflow's Step 4, rather than waiting for it to be populated at a later stage.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a6515d6-01d8-415e-b01f-6c1f52ad151a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a6515d6-01d8-415e-b01f-6c1f52ad151a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

