### PR TITLE
SalesPerson workflow loading

### DIFF
--- a/src/app/(mobile)/customers/customerform/SalesFlow.tsx
+++ b/src/app/(mobile)/customers/customerform/SalesFlow.tsx
@@ -2212,8 +2212,8 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
         identificationFailed={identificationFailed}
       />
 
-      {/* Loading Overlay - Simple overlay for non-BLE operations (customer registration, processing, vehicle assignment) */}
-      {(isCreatingCustomer || isProcessing || isAssigningVehicle) && 
+      {/* Loading Overlay - Simple overlay for non-BLE operations (customer registration, processing, vehicle assignment, service completion) */}
+      {(isCreatingCustomer || isProcessing || isAssigningVehicle || isCompletingService) && 
        !bleScanState.isConnecting && 
        !bleScanState.isReadingEnergy && (
         <div className="loading-overlay active">
@@ -2223,6 +2223,8 @@ export default function SalesFlow({ onBack, onLogout }: SalesFlowProps) {
               ? t('sales.registeringCustomer') || 'Registering customer...'
               : isAssigningVehicle
               ? t('sales.assigningVehicle') || 'Assigning vehicle...'
+              : isCompletingService
+              ? t('sales.completingService') || 'Completing service...'
               : t('common.processing') || 'Processing...'}
           </div>
         </div>


### PR DESCRIPTION
Add `isCompletingService` to the loading overlay condition to show a full-page loading indicator on the last page of the SalesPerson Workflow.

The last page of the SalesPerson Workflow (Step 7 - Battery Assignment) previously only disabled the "Complete Service" button without a full-page loading overlay. This change ensures a consistent loading experience across the flow, similar to other steps and the Attendant flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-fda832be-cf35-45db-81ac-eb4e75377f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fda832be-cf35-45db-81ac-eb4e75377f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

