### PR TITLE
TAPD-1146660095001000658: [factory: ble-app] Divider above the Microsoft button names the wrong provider

### DIFF
--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -12,7 +12,7 @@
   "auth.appTitle": "OVES",
   "auth.appSubtitle": "Sign in to access your workspace",
   "auth.signInWithMicrosoft": "Sign in with Microsoft",
-  "auth.orSignInWith": "or sign in with email",
+  "auth.orSignInWith": "or sign in with Microsoft",
   "auth.noSignInRequired": "No sign-in required",
   "auth.skipToKeypad": "Just need the Keypad? Sign in to access it →",
   "auth.phoneNumber": "Phone Number",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -12,7 +12,7 @@
   "auth.appTitle": "OVES",
   "auth.appSubtitle": "Connectez-vous pour accéder à votre espace de travail",
   "auth.signInWithMicrosoft": "Se connecter avec Microsoft",
-  "auth.orSignInWith": "ou se connecter par e-mail",
+  "auth.orSignInWith": "ou se connecter avec Microsoft",
   "auth.emailPlaceholder": "Adresse e-mail",
   "auth.passwordPlaceholder": "Mot de passe",
   "auth.signIn": "Se connecter",

--- a/src/lib/__tests__/signin-translations.test.ts
+++ b/src/lib/__tests__/signin-translations.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import en from '../../i18n/messages/en.json';
+import fr from '../../i18n/messages/fr.json';
+
+describe('sign-in translations', () => {
+  it('labels the divider with the Microsoft sign-in method in each locale', () => {
+    expect(en['auth.orSignInWith']).toBe('or sign in with Microsoft');
+    expect(fr['auth.orSignInWith']).toBe('ou se connecter avec Microsoft');
+  });
+});


### PR DESCRIPTION
## TAPD-1146660095001000658 — [factory: ble-app] Divider above the Microsoft button names the wrong provider

Seen on https://ble-app.vercel.app/signin

Below the sign-in form there is a horizontal divider whose label reads
"OR SIGN IN WITH EMAIL". The button directly beneath it is
"Sign in with Microsoft".

The label describes the form ABOVE it rather than the button below it, so it
tells the user the wrong thing. It is wrong on both the "Email address" tab and
the "Phone Number" tab - on the phone tab it is doubly wrong, since neither the
form above nor the button below involves email at all.

Source: signin/page.tsx line 309 renders the divider label from the message key
ending in "orSignInWith". The English string is at src/i18n/messages/en.json
line 15 ("or sign in with email") and the French at src/i18n/messages/fr.json
line 15 ("ou se connecter par e-mail").

Expected: the divider names the alternative method it introduces, e.g.
"or sign in with Microsoft" / "ou se connecter avec Microsoft". Update both
locale files.

How to verify: load /signin, look immediately above the Microsoft button on both
tabs.

### Proof
**Without the fix** (new test re-run against the base code):
```
[31m[1mAssertionError[22m: expected 'or sign in with email' to be 'or sign in with Microsoft' // Object.is equality[39m
Expected: [32m"or sign in with [7mMicrosoft[27m"[39m
```
**With the fix** (full suite):
```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - ESM syntax in a file loaded as CommonJS (vitest.config.ts:1:1). Use a `.mjs` extension or set `"type": "module"` in the closest package.json
Set `VITE_CONFIG_NATIVE_IGNORE_WARNING=true` to suppress this warning.

[1m[30m[46m RUN [49m[39m[22m [36mv4.1.11 [39m[90m/work/repo[39m

 [32m✓[39m src/lib/hooks/ble/__tests__/bleFastRead.test.ts [2m([22m[2m18 tests[22m[2m)[22m[32m 17[2mms[22m[39m
 [32m✓[39m src/app/(mobile)/topup/lib/__tests__/topup-core.test.ts [2m([22m[2m28 tests[22m[2m)[22m[32m 18[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/phone.test.ts [2m([22m[2m24 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/html-splash.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m src/app/(mobile)/charger/lib/__tests__/charger-core.test.ts [2m([22m[2m27 tests[22m[2m)[22m[32m 15[2mms[22m[39m
 [32m✓[39m src/lib/qr/__tests__/parseCustomerQr.test.ts [2m([22m[2m14 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m src/app/(mobile)/rider/app/hooks/__tests__/useRiderActivity.test.ts [2m([22m[2m9 tests[22m[2m)[22m[32m 10[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/plan-filter.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/app/(mobile)/rider/app/map/__tests__/deepLinks.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m src/app/(mobile)/rider/app/map/__tests__/gcj02.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/togo-currency.test.ts [2m([22m[2m5 tests[22m[2m)[22m[32m 7[2mms[22m[39m
 [32m✓[39m src/app/(mobile)/rider/app/map/__tests__/isChina.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m src/lib/__tests__/signin-translations.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 6[2mms[22m[39m

[2m Test Files [22m [1m[32m13 passed[39m[22m[90m (13)[39m
[2m      Tests [22m [1m[32m148 passed[39m[22m[90m (148)[39m
[2m   Start at [22m 08:41:30
[2m   Duration [22m 2.76s[2m (transform 368ms, setup 0ms, import 661ms, tests 131ms, environment 2ms)[22m

```

### How to verify by hand
1. `npm install` and `npm test`
2. Check the behaviour described in the task.

---
_Opened by the software factory. This branch cannot merge itself — the dispatcher routes it, and posts the routing decision below._
